### PR TITLE
Parse type qualifiers and translate them to spirv::StorageClass

### DIFF
--- a/include/AST/Types.h
+++ b/include/AST/Types.h
@@ -1,7 +1,39 @@
 #pragma once
 #include <string>
+#include <iostream>
 
 namespace shaderpulse {
+
+enum PrecisionQualifierKind {
+    High,
+    Medium,
+    Low
+};
+
+enum InterpolationQualifierKind {
+    Smooth,
+    Flat,
+    Noperspective
+};
+
+enum StorageQualifierKind {
+    Const,
+    In,
+    Out,
+    Inout,
+    Centroid,
+    Patch,
+    Sample,
+    Uniform,
+    Buffer,
+    Shared,
+    Coherent,
+    Volatile,
+    Restrict,
+    Readonly,
+    Writeonly,
+    Subroutine
+};
 
 enum TypeKind {
     Void,
@@ -16,30 +48,144 @@ enum TypeKind {
     Struct
 };
 
+enum TypeQualifierKind {
+    Storage,
+    Interpolation,
+    Precision,
+    Invariant,
+    Precise
+};
+
+class TypeQualifier {
+
+public:
+    virtual ~TypeQualifier() = default;
+    TypeQualifier(TypeQualifierKind kind) : kind(kind) {
+
+    }
+
+    TypeQualifierKind getKind() const { return kind; }
+
+private:
+    TypeQualifierKind kind;
+};
+
+class StorageQualifier : public TypeQualifier {
+
+public:
+    StorageQualifier(StorageQualifierKind kind) : 
+        TypeQualifier(TypeQualifierKind::Storage), 
+        kind(kind){
+
+    }
+
+    StorageQualifierKind getKind() const { return kind; }
+
+private:
+    StorageQualifierKind kind;
+};
+
+class InterpolationQualifier : public TypeQualifier {
+
+public:
+    InterpolationQualifier(InterpolationQualifierKind kind) : 
+        TypeQualifier(TypeQualifierKind::Interpolation), 
+        kind(kind){
+
+    }
+
+    InterpolationQualifierKind getKind() const { return kind; }
+
+private:
+    InterpolationQualifierKind kind;
+};
+
+class PreciseQualifier : public TypeQualifier {
+
+public:
+    PreciseQualifier() : TypeQualifier(TypeQualifierKind::Precise) {
+
+    }
+};
+
+class InvariantQualifier : public TypeQualifier {
+
+public:
+    InvariantQualifier() : 
+        TypeQualifier(TypeQualifierKind::Invariant) {
+
+    }
+};
+
+
+class PrecisionQualifier : public TypeQualifier {
+
+public:
+    PrecisionQualifier(PrecisionQualifierKind kind) : 
+        TypeQualifier(TypeQualifierKind::Precision), 
+        kind(kind){
+
+    }
+
+    PrecisionQualifierKind getKind() const { return kind; }
+
+private:
+    PrecisionQualifierKind kind;
+};
+
 class Type {
 
 public:
-    Type(TypeKind kind) : kind(kind) {
+    Type(TypeKind kind, std::vector<std::unique_ptr<TypeQualifier>> qualifiers) : 
+        kind(kind),
+        qualifiers(std::move(qualifiers)) {
 
     }
+
     virtual ~Type() = default;
 
     TypeKind getKind() const { return kind; }
+    TypeQualifier* getQualifier(TypeQualifierKind kind) {
+        if (qualifiers.size() == 0) {
+            return nullptr;
+
+        }
+
+        auto it = std::find_if(
+            qualifiers.begin(), 
+            qualifiers.end(), 
+            [&kind](const std::unique_ptr<TypeQualifier>& qualifier) 
+                { 
+                    return qualifier->getKind() == kind; 
+                }
+            );
+
+        if (it != qualifiers.end()) {
+            return it->get();
+        } else {
+            return nullptr;
+        }
+    }
+
     inline bool isScalar() const { return kind >= TypeKind::Void && kind <= TypeKind::Double; }
     inline bool isVector() const { return kind == TypeKind::Vector; }
     inline bool isMatrix() const { return kind == TypeKind::Matrix; }
     inline bool isStruct() const { return kind == TypeKind::Struct; }
     inline bool isOpaque() const { return kind == TypeKind::Opaque; }
 
+    const std::vector<std::unique_ptr<TypeQualifier>> &getQualifiers() { return qualifiers; };
+
+
 private:
     TypeKind kind;
+    std::vector<std::unique_ptr<TypeQualifier>> qualifiers;
 };
 
 class VectorType : public Type {
 
 public:
-    VectorType(std::unique_ptr<Type> elementType, int length) : 
-       Type(TypeKind::Vector), 
+    VectorType(std::vector<std::unique_ptr<TypeQualifier>> qualifiers, std::unique_ptr<Type> elementType, int length) : 
+       Type(TypeKind::Vector, std::move(qualifiers)), 
         elementType(std::move(elementType)), 
         length(length) {
         assert(this->elementType->isScalar());
@@ -56,8 +202,8 @@ private:
 class MatrixType : public Type {
 
 public:
-    MatrixType(std::unique_ptr<Type> elementType, int rows, int cols) :
-        Type(TypeKind::Matrix), 
+    MatrixType(std::vector<std::unique_ptr<TypeQualifier>> qualifiers, std::unique_ptr<Type> elementType, int rows, int cols) :
+        Type(TypeKind::Matrix, std::move(qualifiers)), 
         elementType(std::move(elementType)), 
         rows(rows), 
         cols(cols) {
@@ -78,8 +224,8 @@ private:
 class StructType : public Type {
 
 public:
-    StructType(const std::string& structName) : 
-        Type(TypeKind::Struct),
+    StructType(std::vector<std::unique_ptr<TypeQualifier>> qualifiers, const std::string& structName) : 
+        Type(TypeKind::Struct, std::move(qualifiers)),
         structName(structName) {
 
         }

--- a/include/CodeGen/TypeConversion.h
+++ b/include/CodeGen/TypeConversion.h
@@ -1,13 +1,14 @@
 #pragma once
 #include "AST/Types.h"
 #include "mlir/IR/BuiltinTypes.h"
-
+#include "mlir/Dialect/SPIRV/IR/SPIRVOps.h"
 
 namespace shaderpulse {
 
 namespace codegen {
 
 mlir::Type convertShaderPulseType(mlir::MLIRContext*, Type*);
+std::optional<mlir::spirv::StorageClass> getSpirvStorageClass(TypeQualifier*);
 
 }; // namespace codegen
 }; // namespace shaderpulse

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -49,6 +49,9 @@ public:
     std::unique_ptr<ast::CallExpression> parseCallExpression();
     std::unique_ptr<ast::Expression> parseUnaryExpression();
     std::unique_ptr<ast::Expression> parsePostfixExpression();
+    std::vector<std::unique_ptr<TypeQualifier>> parseQualifiers();
+    std::unique_ptr<TypeQualifier> parseQualifier();
+    std::unique_ptr<Type> parseType();
 
 private:
     std::vector<std::unique_ptr<Token>>& tokenStream;
@@ -62,9 +65,9 @@ private:
     static std::optional<ast::BinaryOperator> getBinaryOperatorFromTokenKind(TokenKind);
     static std::optional<ast::UnaryOperator> getUnaryOperatorFromTokenKind(TokenKind);
     static std::optional<ast::AssignmentOperator> getAssignmentOperatorFromTokenKind(TokenKind);
-    static std::optional<std::unique_ptr<shaderpulse::Type>> getTypeFromTokenKind(TokenKind);
-    static std::unique_ptr<shaderpulse::VectorType> makeVectorType(TypeKind, int);
-    static std::unique_ptr<shaderpulse::MatrixType> makeMatrixType(TypeKind, int, int);
+    static std::unique_ptr<shaderpulse::Type> getTypeFromTokenKind(std::vector<std::unique_ptr<TypeQualifier>>, TokenKind);
+    static std::unique_ptr<shaderpulse::VectorType> makeVectorType(std::vector<std::unique_ptr<TypeQualifier>>, TypeKind, int);
+    static std::unique_ptr<shaderpulse::MatrixType> makeMatrixType(std::vector<std::unique_ptr<TypeQualifier>>, TypeKind, int, int);
 };
 
 } // namespace shaderpulse

--- a/lib/CodeGen/TypeConversion.cpp
+++ b/lib/CodeGen/TypeConversion.cpp
@@ -34,6 +34,30 @@ mlir::Type convertShaderPulseType(mlir::MLIRContext* ctx, Type* shaderPulseType)
     }
 }
 
+
+std::optional<mlir::spirv::StorageClass> getSpirvStorageClass(TypeQualifier* typeQualifier) {
+    if (!typeQualifier) {
+        return std::nullopt;
+    }
+
+    if (typeQualifier->getKind() == TypeQualifierKind::Storage) {
+        auto storageQualifier = dynamic_cast<StorageQualifier*>(typeQualifier);
+
+        switch (storageQualifier->getKind()) {
+            case StorageQualifierKind::Uniform:
+                return mlir::spirv::StorageClass::Uniform;
+            case StorageQualifierKind::In:
+                return mlir::spirv::StorageClass::Input;
+            case StorageQualifierKind::Out:
+                return mlir::spirv::StorageClass::Output;
+            default:
+                std::nullopt;
+        }
+    }
+    
+    return std::nullopt;
+}
+
 };
 
 };

--- a/standalone/shaderpulse.cpp
+++ b/standalone/shaderpulse.cpp
@@ -5,8 +5,8 @@
 
 static std::string functionDeclarationTestString = 
 R"( 
-    float a;
-    int b;
+    uniform highp float a;
+    uniform int b;
     uint c;
     vec3 d;
     mat2x2 e;


### PR DESCRIPTION
- Implement parsing all the `GLSL` type qualifiers
- Start converting the qualifiers to `spirv`: some of the `shaderpulse::StorageQualifierKind`s can be converted to `spirv::StorageClass`, namely `Uniform`, `In` and `Out`. No qualifier means `spirv::Private` in case of a global variable.