### PR TITLE
Support vector and matrix composite constructs

### DIFF
--- a/example/constructor.glsl
+++ b/example/constructor.glsl
@@ -1,0 +1,15 @@
+vec3 foo() {
+    vec3 a = vec3(0.0, 0.1, 0.2);
+    vec3 b = vec3(1.1, 1.2, 1.2);
+    mat2 testMat = mat2(1.2, 2.3, 
+                        3.4, 4.5);
+
+
+    if (a < b) {
+        a = 2.0;
+    } else {
+        a = 3.0;
+    }
+
+    return 0.0;
+}

--- a/example/constructor.glsl
+++ b/example/constructor.glsl
@@ -1,15 +1,14 @@
-vec3 foo() {
+bool foo() {
     vec3 a = vec3(0.0, 0.1, 0.2);
     vec3 b = vec3(1.1, 1.2, 1.2);
     mat2 testMat = mat2(1.2, 2.3, 
                         3.4, 4.5);
 
+    
+    mat3 testMat = mat3(1.2, 2.3, 3.4,
+                        4.5, 5.6, 6.7,
+                        7.8, 8.9, 9.1);
 
-    if (a < b) {
-        a = 2.0;
-    } else {
-        a = 3.0;
-    }
+    return true;
 
-    return 0.0;
 }

--- a/include/AST/AST.h
+++ b/include/AST/AST.h
@@ -154,6 +154,35 @@ private:
   std::vector<std::unique_ptr<Expression>> arguments;
 };
 
+class ConstructorExpression : public Expression {
+
+public:
+    ConstructorExpression(std::unique_ptr<Type> type) : 
+      type(std::move(type))  {
+
+    }
+
+  ConstructorExpression(std::unique_ptr<Type> type, 
+    std::vector<std::unique_ptr<Expression>> arguments) : 
+      type(std::move(type)), 
+      arguments(std::move(arguments))  {
+
+    }
+
+  void accept(ASTVisitor *visitor) override {
+    visitor->visit(this);
+  }
+
+  Type *getType() const { return type.get(); }
+  const std::vector<std::unique_ptr<Expression>> &getArguments() const {
+    return arguments;
+  }
+
+private:
+  std::unique_ptr<Type> type;
+  std::vector<std::unique_ptr<Expression>> arguments;
+};
+
 class UnaryExpression : public Expression {
 
 public:

--- a/include/AST/ASTVisitor.h
+++ b/include/AST/ASTVisitor.h
@@ -16,6 +16,7 @@ class IfStatement;
 class AssignmentExpression;
 class StatementList;
 class CallExpression;
+class ConstructorExpression;
 class VariableExpression;
 class IntegerConstantExpression;
 class UnsignedIntegerConstantExpression;
@@ -46,6 +47,7 @@ public:
   virtual void visit(AssignmentExpression *) { };
   virtual void visit(StatementList *) { };
   virtual void visit(CallExpression *) { };
+  virtual void visit(ConstructorExpression *) { };
   virtual void visit(VariableExpression *) { };
   virtual void visit(IntegerConstantExpression *) { };
   virtual void visit(UnsignedIntegerConstantExpression *) { };

--- a/include/AST/Types.h
+++ b/include/AST/Types.h
@@ -110,6 +110,9 @@ private:
 class Type {
 
 public:
+
+  Type(TypeKind kind)
+      : kind(kind), qualifiers(std::vector<std::unique_ptr<TypeQualifier>>()) {}
   Type(TypeKind kind, std::vector<std::unique_ptr<TypeQualifier>> qualifiers)
       : kind(kind), qualifiers(std::move(qualifiers)) {}
 
@@ -154,6 +157,11 @@ private:
 class VectorType : public Type {
 
 public:
+VectorType(std::unique_ptr<Type> elementType, int length)
+      : Type(TypeKind::Vector, std::vector<std::unique_ptr<TypeQualifier>>()),
+        elementType(std::move(elementType)), length(length) {
+    assert(this->elementType->isScalar());
+  }
   VectorType(std::vector<std::unique_ptr<TypeQualifier>> qualifiers,
              std::unique_ptr<Type> elementType, int length)
       : Type(TypeKind::Vector, std::move(qualifiers)),

--- a/include/CodeGen/MLIRCodeGen.h
+++ b/include/CodeGen/MLIRCodeGen.h
@@ -61,6 +61,7 @@ public:
   void visit(AssignmentExpression *) override;
   void visit(StatementList *) override;
   void visit(CallExpression *) override;
+  void visit(ConstructorExpression *) override;
   void visit(VariableExpression *) override;
   void visit(IntegerConstantExpression *) override;
   void visit(UnsignedIntegerConstantExpression *) override;

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -50,6 +50,7 @@ public:
   std::unique_ptr<CaseLabel> parseCaseLabel();
   std::unique_ptr<DefaultLabel> parseDefaultLabel();
   std::unique_ptr<CallExpression> parseCallExpression();
+  std::unique_ptr<ConstructorExpression> parseConstructorExpression();
   std::unique_ptr<Expression> parseUnaryExpression();
   std::unique_ptr<Expression> parsePostfixExpression();
   std::vector<std::unique_ptr<TypeQualifier>> parseQualifiers();

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -272,6 +272,22 @@ void MLIRCodeGen::visit(WhileStatement *whileStmt) {
   builder.setInsertionPointToEnd(restoreInsertionBlock);
 }
 
+void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
+  std::vector<mlir::Value> operands;
+
+  if (constructorExp->getArguments().size() > 0) {
+    for (auto &arg : constructorExp->getArguments()) {
+      arg->accept(this);
+      operands.push_back(popExpressionStack());
+    }
+  }
+
+  mlir::Value val = builder.create<spirv::CompositeConstructOp>(
+        builder.getUnknownLoc(), convertShaderPulseType(&context, constructorExp->getType()), operands);
+
+  expressionStack.push_back(val);
+}
+
 void MLIRCodeGen::visit(DoStatement *doStmt) {
 
 }

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -215,7 +215,9 @@ void MLIRCodeGen::createVariable(shaderpulse::Type *type,
                                 spirv::StorageClass::Function);
 
     auto var = builder.create<spirv::VariableOp>(
-        builder.getUnknownLoc(), ptrType, spirv::StorageClass::Function, val);
+        builder.getUnknownLoc(), ptrType, spirv::StorageClass::Function, nullptr);
+
+    builder.create<spirv::StoreOp>(builder.getUnknownLoc(), var, val);
 
     declare(varDecl, var);
   }
@@ -273,6 +275,7 @@ void MLIRCodeGen::visit(WhileStatement *whileStmt) {
 }
 
 void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
+  auto constructorType = constructorExp->getType();
   std::vector<mlir::Value> operands;
 
   if (constructorExp->getArguments().size() > 0) {
@@ -282,10 +285,43 @@ void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
     }
   }
 
-  mlir::Value val = builder.create<spirv::CompositeConstructOp>(
-        builder.getUnknownLoc(), convertShaderPulseType(&context, constructorExp->getType()), operands);
+  switch (constructorType->getKind()) {
+    case TypeKind::Vector: {
+      mlir::Value val = builder.create<spirv::CompositeConstructOp>(
+            builder.getUnknownLoc(), convertShaderPulseType(&context, constructorType), operands);
+      expressionStack.push_back(val);
+      break;
+    }
 
-  expressionStack.push_back(val);
+    case TypeKind::Matrix: {
+      auto matrixType = dynamic_cast<shaderpulse::MatrixType *>(constructorType);
+      std::vector<mlir::Value> columnVectors;
+
+      for (int i = 0; i < matrixType->getCols(); i++) {
+        std::vector<mlir::Value> col;
+
+        for (int j = 0; j < matrixType->getRows(); j++) {
+          col.push_back(operands[j*matrixType->getCols() + i]);
+        }
+
+        auto elementType = std::make_unique<Type>(matrixType->getElementType()->getKind());
+        auto vecType = std::make_unique<shaderpulse::VectorType>(std::move(elementType), col.size());
+        mlir::Value val = builder.create<spirv::CompositeConstructOp>(
+          builder.getUnknownLoc(), convertShaderPulseType(&context, vecType.get()), col);
+        columnVectors.push_back(val);
+      }
+
+      mlir::Value val = builder.create<spirv::CompositeConstructOp>(
+        builder.getUnknownLoc(), convertShaderPulseType(&context, constructorType), columnVectors);
+
+      expressionStack.push_back(val);
+      break;
+    }
+
+    default:
+      // Unsupported composite construct
+      break;
+  }
 }
 
 void MLIRCodeGen::visit(DoStatement *doStmt) {

--- a/lib/CodeGen/TypeConversion.cpp
+++ b/lib/CodeGen/TypeConversion.cpp
@@ -27,12 +27,12 @@ mlir::Type convertShaderPulseType(mlir::MLIRContext *ctx,
         shape, convertShaderPulseType(ctx, vecType->getElementType()));
   }
   case TypeKind::Matrix: {
+    // Need to create a spirv::MatrixType here, defined as columns of vectors
     auto matrixType = dynamic_cast<shaderpulse::MatrixType *>(shaderPulseType);
-    llvm::SmallVector<int64_t, 2> shape;
+    llvm::SmallVector<int64_t, 1> shape;
     shape.push_back(matrixType->getRows());
-    shape.push_back(matrixType->getCols());
-    return mlir::VectorType::get(
-        shape, convertShaderPulseType(ctx, matrixType->getElementType()));
+    auto colVectorType = mlir::VectorType::get(shape, convertShaderPulseType(ctx, matrixType->getElementType()));
+    return mlir::spirv::MatrixType::get(colVectorType, matrixType->getCols());
   }
   }
 }


### PR DESCRIPTION
- Support parsing constructor expressions (for built-in types, struct constructors are not yet supported)
- Support generating code for `vec`s and `mat`s by utilizing `spirv::CompositeConstructOp`
- Since we don't yet support const checking (and semantic analysis in general), we don't use initiializer expression in variable declarations, but use `Store` instead