### PR TITLE
Support storing to composites through AccessChain

### DIFF
--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -15,6 +15,7 @@ struct A {
 void main() {
   A a = A(1.0, 2.0, 3.0, B(1.2, 1.3));
   float test = a.b.d;
+  a.b.d = 1.0;
   outColor = vec4(test, 0.0, 0.0, 1.0);
   return;
 }

--- a/include/CodeGen/MLIRCodeGen.h
+++ b/include/CodeGen/MLIRCodeGen.h
@@ -113,6 +113,7 @@ private:
   void insertEntryPoint();
   
   mlir::Value popExpressionStack();
+  mlir::Value currentBasePointer;
 };
 
 }; // namespace codegen

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -18,7 +18,7 @@ class Parser {
 
 public:
   Parser(std::vector<std::unique_ptr<Token>> &tokens)
-      : tokenStream(tokens), cursor(-1), curToken(nullptr) {
+      : tokenStream(tokens), cursor(-1), curToken(nullptr), parsingLhsExpression(false) {
     advanceToken();
   }
 
@@ -69,6 +69,7 @@ private:
   void advanceToken();
   const Token *peek(int);
   int savedPosition;
+  bool parsingLhsExpression;
 
   // TODO: move these to ast helpers
   static std::map<BinaryOperator, int> binopPrecedence;

--- a/lib/AST/PrinterASTVisitor.cpp
+++ b/lib/AST/PrinterASTVisitor.cpp
@@ -98,7 +98,7 @@ void PrinterASTVisitor::visit(IfStatement *ifStmt) {
 }
 
 void PrinterASTVisitor::visit(AssignmentExpression *assignmentExp) {
-  print("|-AssignmentExpression: variable name=" + assignmentExp->getIdentifier());
+  //print("|-AssignmentExpression: variable name=" + assignmentExp->getIdentifier());
   indent();
   assignmentExp->getExpression()->accept(this);
   resetIndent();


### PR DESCRIPTION
Needs cleanup, but things like `a.b.d = 1.0;` now work.