### PR TITLE
Error reporting improvements

### DIFF
--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -10,7 +10,7 @@ struct A {
   float y;
   float z;
   B b;
-};
+;
 
 void main() {
   A a = A(1.0, 2.0, 3.0, B(1.2, 1.3));

--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -10,7 +10,7 @@ struct A {
   float y;
   float z;
   B b;
-;
+};
 
 void main() {
   A a = A(1.0, 2.0, 3.0, B(1.2, 1.3));

--- a/include/Lexer/Lexer.h
+++ b/include/Lexer/Lexer.h
@@ -35,7 +35,7 @@ struct Error {
 class Lexer {
 public:
   Lexer(const std::string &characters)
-      : characters(characters), curCharPos(0), lineNum(1), col(1) {}
+      : characters(characters), curCharPos(0), savedCharPos(0), lineNum(1), col(1) {}
 
   tl::expected<std::reference_wrapper<std::vector<std::unique_ptr<Token>>>,
                Error>
@@ -47,6 +47,7 @@ public:
 private:
   std::string characters;
   int curCharPos;
+  int savedCharPos;
   int lineNum;
   int col;
   std::vector<std::unique_ptr<Token>> tokenStream;

--- a/include/Lexer/Token.h
+++ b/include/Lexer/Token.h
@@ -85,11 +85,14 @@ public:
   void setLiteralData(std::unique_ptr<NumericLiteral>);
   void setSourceLocation(SourceLocation loc);
   SourceLocation getSourceLocation() const;
+  void setRawData(const std::string&);
+  std::string getRawData() const;
 
 private:
   TokenKind tokenKind;
   SourceLocation sourceLoc;
   std::string identifierName;
+  std::string rawData;
   std::unique_ptr<NumericLiteral> literalData;
 };
 

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -14,6 +14,22 @@ using namespace ast;
 
 namespace parser {
 
+enum ParserErrorKind {
+  None,
+  UnexpectedToken,
+  ExpectedToken
+};
+
+struct ParserError {
+  ParserError() : kind(ParserErrorKind::None) {}
+  ParserError(ParserErrorKind kind, const std::string &msg) : kind(kind), msg(msg) {}
+
+  ParserErrorKind kind;
+  std::string msg;
+
+  bool none() { return kind == ParserErrorKind::None; }
+};
+
 class Parser {
 
 public:
@@ -68,6 +84,8 @@ private:
   Token *curToken;
   void advanceToken();
   const Token *peek(int);
+  ParserError error;
+  void reportError(ParserErrorKind kind, const std::string &msg);
   int savedPosition;
   bool parsingLhsExpression;
 

--- a/lib/Lexer/Lexer.cpp
+++ b/lib/Lexer/Lexer.cpp
@@ -110,6 +110,7 @@ bool Lexer::handleIdentifier(Error &error) {
   }
 
   tok->setSourceLocation(SourceLocation(lineNum, startCol));
+  tok->setRawData(token);
   tokenStream.push_back(std::move(tok));
 
   return true;
@@ -156,6 +157,7 @@ bool Lexer::handleHexLiteral(Error &error) {
     tok->setTokenKind(isUnsigned ? TokenKind::UnsignedIntegerConstant
                                  : TokenKind::IntegerConstant);
     tok->setSourceLocation(SourceLocation(lineNum, startCol));
+    tok->setRawData(literalConstant);
     tokenStream.push_back(std::move(tok));
 
     return true;
@@ -205,6 +207,7 @@ bool Lexer::handleOctalLiteral(Error &error) {
                                  : TokenKind::IntegerConstant);
 
     tok->setSourceLocation(SourceLocation(lineNum, startCol));
+    tok->setRawData(literalConstant);
     tokenStream.push_back(std::move(tok));
 
     return true;
@@ -254,6 +257,7 @@ bool Lexer::handleDecimalOrFloatLiteral(Error &error) {
           std::make_unique<FloatLiteral>(std::stof(literalConstant)));
       tok->setTokenKind(TokenKind::FloatConstant);
       tok->setSourceLocation(SourceLocation(lineNum, startCol));
+      tok->setRawData(literalConstant);
       tokenStream.push_back(std::move(tok));
       return true;
     }
@@ -272,6 +276,7 @@ bool Lexer::handleDecimalOrFloatLiteral(Error &error) {
     }
 
     tok->setSourceLocation(SourceLocation(lineNum, startCol));
+    tok->setRawData(literalConstant);
     tokenStream.push_back(std::move(tok));
     return true;
   } else {
@@ -316,6 +321,7 @@ bool Lexer::handleExponentialForm(std::string &literalConstant, Error &error) {
         std::make_unique<FloatLiteral>(std::stof(literalConstant)));
     tok->setTokenKind(TokenKind::FloatConstant);
     tok->setSourceLocation(SourceLocation(lineNum, startCol));
+    tok->setRawData(literalConstant);
     tokenStream.push_back(std::move(tok));
 
     return true;
@@ -537,6 +543,7 @@ void Lexer::addToken(TokenKind kind) {
   auto tok = std::make_unique<Token>();
   tok->setTokenKind(kind);
   tok->setSourceLocation(SourceLocation(lineNum, col));
+  tok->setRawData(Lexer::getSpelling(kind));
   tokenStream.push_back(std::move(tok));
 }
 

--- a/lib/Lexer/Lexer.cpp
+++ b/lib/Lexer/Lexer.cpp
@@ -342,6 +342,8 @@ bool Lexer::handlePunctuator(Error &error) {
     return false;
   }
 
+  savedCharPos = curCharPos;
+
   switch (getCurChar()) {
   case '<': {
     if (peekChar() == '<') {
@@ -543,7 +545,8 @@ void Lexer::addToken(TokenKind kind) {
   auto tok = std::make_unique<Token>();
   tok->setTokenKind(kind);
   tok->setSourceLocation(SourceLocation(lineNum, col));
-  tok->setRawData(Lexer::getSpelling(kind));
+  std::string rawData = characters.substr(savedCharPos, curCharPos - savedCharPos + 1);
+  tok->setRawData(rawData);
   tokenStream.push_back(std::move(tok));
 }
 

--- a/lib/Lexer/Token.cpp
+++ b/lib/Lexer/Token.cpp
@@ -48,6 +48,14 @@ SourceLocation Token::getSourceLocation() const {
   return sourceLoc;
 }
 
+void Token::setRawData(const std::string& rawData) {
+  this->rawData = rawData;
+}
+
+std::string Token::getRawData() const {
+  return rawData;
+}
+
 }; // namespace lexer
 
 }; // namespace shaderpulse

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -128,7 +128,7 @@ std::unique_ptr<Declaration> Parser::parseDeclaration() {
         return std::make_unique<VariableDeclaration>(std::move(type), name,
                                                      std::move(exp));
       } else {
-        std::cout << "Parser error: unexpected token." << cursor << std::endl;
+        std::cout << "Parser error: unexpected token '" << curToken->getRawData() << "' at line " << curToken->getSourceLocation().line << ", col: " <<  curToken->getSourceLocation().col << std::endl;
       }
     } else if (curToken->is(TokenKind::comma)) {
       advanceToken();

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -71,8 +71,7 @@ std::unique_ptr<FunctionDeclaration> Parser::parseFunctionDeclaration() {
     auto params = parseFunctionParameters();
 
     if (!curToken->is(TokenKind::rParen)) {
-      std::cout << "Expected a ')' after function parameter declaration."
-                << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after function parameter declaration.");
       return nullptr;
     }
 
@@ -128,7 +127,7 @@ std::unique_ptr<Declaration> Parser::parseDeclaration() {
         return std::make_unique<VariableDeclaration>(std::move(type), name,
                                                      std::move(exp));
       } else {
-        std::cout << "Parser error: unexpected token '" << curToken->getRawData() << "' at line " << curToken->getSourceLocation().line << ", col: " <<  curToken->getSourceLocation().col << std::endl;
+        reportError(ParserErrorKind::UnexpectedToken, "Parser error: unexpected token '" + curToken->getRawData() + "'");
       }
     } else if (curToken->is(TokenKind::comma)) {
       advanceToken();
@@ -153,7 +152,7 @@ std::unique_ptr<VariableDeclarationList> Parser::parseVariableDeclarationList(
 
   do {
     if (!curToken->is(TokenKind::Identifier)) {
-      std::cout << "Parser error: expected identifier" << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Parser error: expected identifier");
     }
 
     const std::string &varName = curToken->getIdentifierName();
@@ -175,8 +174,7 @@ std::unique_ptr<VariableDeclarationList> Parser::parseVariableDeclarationList(
   } while (curToken->is(TokenKind::comma));
 
   if (!curToken->is(TokenKind::semiColon)) {
-    std::cout << "Expected semicolon after variable declaration list."
-              << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected semicolon after variable declaration list.");
   }
 
   advanceToken();
@@ -692,7 +690,7 @@ std::unique_ptr<SwitchStatement> Parser::parseSwitchStatement() {
   advanceToken();
 
   if (!curToken->is(TokenKind::lParen)) {
-    std::cout << "Expected a '(' after switch keyword." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a '(' after switch keyword.");
     return nullptr;
   }
 
@@ -705,7 +703,7 @@ std::unique_ptr<SwitchStatement> Parser::parseSwitchStatement() {
   }
 
   if (!curToken->is(TokenKind::rParen)) {
-    std::cout << "Expected a ')' after condition." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after condition.");
     return nullptr;
   }
 
@@ -728,7 +726,7 @@ std::unique_ptr<WhileStatement> Parser::parseWhileStatement() {
   advanceToken();
 
   if (!curToken->is(TokenKind::lParen)) {
-    std::cout << "Expected a '(' after while keyword." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a '(' after while keyword.");
     return nullptr;
   }
 
@@ -737,8 +735,7 @@ std::unique_ptr<WhileStatement> Parser::parseWhileStatement() {
   auto exp = parseExpression();
 
   if (!curToken->is(TokenKind::rParen)) {
-    std::cout << "Expected a ')' after condition expression." << cursor
-              << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after condition expression.");
     return nullptr;
   }
 
@@ -760,14 +757,14 @@ std::unique_ptr<DoStatement> Parser::parseDoStatement() {
 
   if (auto stmt = parseStatement()) {
     if (!curToken->is(TokenKind::kw_while)) {
-      std::cout << "Expected while keyword after statement list." << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Expected while keyword after statement list.");
       return nullptr;
     }
 
     advanceToken();
 
     if (!curToken->is(TokenKind::lParen)) {
-      std::cout << "Expected a '(' after while keyword." << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Expected a '(' after while keyword.");
       return nullptr;
     }
 
@@ -776,15 +773,14 @@ std::unique_ptr<DoStatement> Parser::parseDoStatement() {
     auto exp = parseExpression();
 
     if (!curToken->is(TokenKind::rParen)) {
-      std::cout << "Expected a ')' after condition expression." << cursor
-                << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after condition expression.");
       return nullptr;
     }
 
     advanceToken();
 
     if (!curToken->is(TokenKind::semiColon)) {
-      std::cout << "Expected a semicolon after while statement." << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Expected a semicolon after while statement.");
       return nullptr;
     }
 
@@ -804,7 +800,7 @@ std::unique_ptr<IfStatement> Parser::parseIfStatement() {
   advanceToken();
 
   if (!curToken->is(TokenKind::lParen)) {
-    std::cout << "Expected a '(' after if keyword." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a '(' after if keyword.");
     return nullptr;
   }
 
@@ -817,7 +813,7 @@ std::unique_ptr<IfStatement> Parser::parseIfStatement() {
   }
 
   if (!curToken->is(TokenKind::rParen)) {
-    std::cout << "Expected a ')' after condition." << cursor << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after condition.");
     return nullptr;
   }
 
@@ -861,7 +857,7 @@ std::unique_ptr<CaseLabel> Parser::parseCaseLabel() {
   }
 
   if (!curToken->is(TokenKind::colon)) {
-    std::cout << "Expected a ':' after case label." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ':' after case label.");
     return nullptr;
   }
 
@@ -878,7 +874,7 @@ std::unique_ptr<DefaultLabel> Parser::parseDefaultLabel() {
   advanceToken();
 
   if (!curToken->is(TokenKind::colon)) {
-    std::cout << "Expected a ':' after case label." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ':' after case label.");
     return nullptr;
   }
 
@@ -906,7 +902,7 @@ std::unique_ptr<Statement> Parser::parseCompoundStatement() {
 
   if (auto stmtList = parseStatementList()) {
     if (!curToken->is(TokenKind::rCurly)) {
-      std::cout << "Expected '}' after statement list." << cursor << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Expected '}' after statement list.");
       return nullptr;
     } else {
       advanceToken();
@@ -978,7 +974,7 @@ std::unique_ptr<ReturnStatement> Parser::parseReturn() {
   auto exp = parseExpression();
 
   if (!curToken->is(TokenKind::semiColon)) {
-    std::cout << "Expected semicolon after return statement." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected semicolon after return statement.");
     return nullptr;
   }
 
@@ -1012,8 +1008,7 @@ std::unique_ptr<AssignmentExpression> Parser::parseAssignmentExpression() {
   auto exp = parseExpression();
 
   if (!curToken->is(TokenKind::semiColon)) {
-    std::cout << "Expected a semicolon after assignment expression." << cursor
-              << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a semicolon after assignment expression.");
   }
 
   advanceToken();
@@ -1029,7 +1024,7 @@ std::unique_ptr<DiscardStatement> Parser::parseDiscard() {
   advanceToken();
 
   if (!curToken->is(TokenKind::semiColon)) {
-    std::cout << "Expected semicolon after discard statement." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected semicolon after discard statement.");
     return nullptr;
   }
 
@@ -1046,7 +1041,7 @@ std::unique_ptr<BreakStatement> Parser::parseBreak() {
   advanceToken();
 
   if (!curToken->is(TokenKind::semiColon)) {
-    std::cout << "Expected semicolon after break statement." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected semicolon after break statement.");
     return nullptr;
   }
 
@@ -1063,7 +1058,7 @@ std::unique_ptr<ContinueStatement> Parser::parseContinue() {
   advanceToken();
 
   if (!curToken->is(TokenKind::semiColon)) {
-    std::cout << "Expected semicolon after continue statement." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected semicolon after continue statement.");
     return nullptr;
   }
 
@@ -1133,7 +1128,7 @@ std::unique_ptr<Expression> Parser::parsePrimaryExpression() {
     }
 
     if (!curToken->is(TokenKind::rParen)) {
-      std::cout << "Expected a ')' after expression." << std::endl;
+      reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after expression.");
       return nullptr;
     }
 
@@ -1215,7 +1210,7 @@ std::unique_ptr<ConstructorExpression> Parser::parseConstructorExpression() {
   } while (true);
 
   if (!curToken->is(TokenKind::rParen)) {
-    std::cout << "Expected a ')' after parameter list in constructor." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after parameter list in constructor.");
     return nullptr;
   }
 
@@ -1230,7 +1225,7 @@ std::unique_ptr<StructDeclaration> Parser::parseStructDeclaration() {
   advanceToken();
 
   if (!curToken->is(TokenKind::Identifier)) {
-    std::cout << "Expect an identifier after struct keyword" << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expect an identifier after struct keyword");
     return nullptr;
   }
 
@@ -1239,7 +1234,7 @@ std::unique_ptr<StructDeclaration> Parser::parseStructDeclaration() {
   advanceToken();
 
   if (!curToken->is(TokenKind::lCurly)) {
-    std::cout << "Expected '{' after struct name." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected '{' after struct name.");
     return nullptr;
   }
 
@@ -1300,7 +1295,7 @@ std::unique_ptr<CallExpression> Parser::parseCallExpression() {
   } while (true);
 
   if (!curToken->is(TokenKind::rParen)) {
-    std::cout << "Expected a ')' after parameter list." << std::endl;
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after parameter list.");
     return nullptr;
   }
 
@@ -1315,7 +1310,6 @@ void Parser::advanceToken() {
     curToken = tokenStream.back().get();
   } else {
     curToken = tokenStream[++cursor].get();
-    std::cout << "Cur token is at line: " << curToken->getSourceLocation().line << ", col: " << curToken->getSourceLocation().col << std::endl;
   }
 }
 
@@ -1331,7 +1325,7 @@ const Token *Parser::peek(int k) {
 }
 
 void Parser::reportError(ParserErrorKind kind, const std::string &msg) {
-  std::cout << msg << std::endl;
+  std::cout << msg << std::endl << ", at line: " << curToken->getSourceLocation().line << ", col: " << curToken->getSourceLocation().col << std::endl;
   error = ParserError(kind, msg);
 }
 

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -1252,7 +1252,7 @@ std::unique_ptr<StructDeclaration> Parser::parseStructDeclaration() {
   }
 
   if (!curToken->is(TokenKind::rCurly)) {
-    std::cout << "Expected a '}' after struct member declaration.";
+    reportError(ParserErrorKind::ExpectedToken, "Expected a '}' after struct member declaration.");
     return nullptr;
   }
 
@@ -1328,6 +1328,11 @@ const Token *Parser::peek(int k) {
   } else {
     return tokenStream[cursor + k].get();
   }
+}
+
+void Parser::reportError(ParserErrorKind kind, const std::string &msg) {
+  std::cout << msg << std::endl;
+  error = ParserError(kind, msg);
 }
 
 }; // namespace parser


### PR DESCRIPTION
- Introduce `ParserError`
- `reportError()` to detect and print parser errors
- save raw string representation of tokens
