### PR TITLE
Improve AST printing

### DIFF
--- a/include/AST/PrinterASTVisitor.h
+++ b/include/AST/PrinterASTVisitor.h
@@ -27,7 +27,9 @@ public:
   void visit(IntegerConstantExpression *) override;
   void visit(UnsignedIntegerConstantExpression *) override;
   void visit(FloatConstantExpression *) override;
+  void visit(ConstructorExpression *) override;
   void visit(DoubleConstantExpression *) override;
+  void visit(MemberAccessExpression *) override;
   void visit(BoolConstantExpression *) override;
   void visit(ReturnStatement *) override;
   void visit(BreakStatement *) override;
@@ -42,7 +44,6 @@ private:
   void resetIndent();
   void print(const std::string &text);
   int indentationLevel = 0;
-  int prevIndentationLevel = 0;
 };
 
 }; // namespace ast


### PR DESCRIPTION
AST printing is a pre-requisite for clean parser tests. For a given test, there will be two files:
1. an input glsl source file
2. an expected output of the printed ast

This PR improves on the existing ast printing, by introducing the following:
- Print `MemberAccessExpression`
- Print `ConstructorExpression`
- Print `StructDeclaration`
- Improve `AssignmentExpression` printing
- Increase indentation of a level to 2 spaces

More feature and refinements will be added incrementally. In general, the printed AST is inspired by the Clang AST printing syntax, so there's work to do to match (close to) it.