### PR TITLE
Parse array types

### DIFF
--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -15,7 +15,7 @@ struct A {
 void main() {
   A a = A(1.0, 2.0, 3.0, B(1.2, 1.3));
   float test = a.b.d;
-  float[2] arr = float[2](1.0, 2.0);
+  float[2][3][4] arr = float[2][3][4](1.0, 2.0);
 
   for (int i = 0; i < 10; i++) {
     int j = 1;

--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -15,6 +15,7 @@ struct A {
 void main() {
   A a = A(1.0, 2.0, 3.0, B(1.2, 1.3));
   float test = a.b.d;
+  float[2] arr = float[2](1.0, 2.0);
 
   for (int i = 0; i < 10; i++) {
     int j = 1;

--- a/include/AST/Types.h
+++ b/include/AST/Types.h
@@ -36,7 +36,8 @@ enum TypeKind {
   Vector,
   Matrix,
   Opaque,
-  Struct
+  Struct,
+  Array
 };
 
 enum TypeQualifierKind {
@@ -176,6 +177,28 @@ VectorType(std::unique_ptr<Type> elementType, int length)
 private:
   std::unique_ptr<Type> elementType;
   int length;
+};
+
+class ArrayType : public Type {
+
+public:
+  ArrayType(std::unique_ptr<Type> elementType, const std::vector<int>& dimensions)
+      : Type(TypeKind::Array, std::vector<std::unique_ptr<TypeQualifier>>()),
+        elementType(std::move(elementType)), dimensions(dimensions) {
+  }
+  
+  ArrayType(std::vector<std::unique_ptr<TypeQualifier>> qualifiers,
+             std::unique_ptr<Type> elementType, const std::vector<int>& dimensions)
+      : Type(TypeKind::Array, std::move(qualifiers)),
+        elementType(std::move(elementType)), dimensions(dimensions) {
+  }
+
+  Type *getElementType() const { return elementType.get(); };
+  const std::vector<int> &getDimensions() { return dimensions; };
+
+private:
+  std::unique_ptr<Type> elementType;
+  std::vector<int> dimensions;
 };
 
 class MatrixType : public Type {

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -79,6 +79,7 @@ public:
 private:
   std::vector<std::unique_ptr<Token>> &tokenStream;
   std::map<std::string, bool> structDeclarations;
+  std::vector<int> savedPositions;
   
   int cursor;
   Token *curToken;
@@ -106,11 +107,12 @@ private:
                  int);
 
   void savePosition() {
-    savedPosition = cursor;
+    savedPositions.push_back(cursor);
   }
 
   void rollbackPosition() {
-    cursor = savedPosition - 1;
+    cursor = savedPositions.back() - 1;
+    savedPositions.pop_back();
     advanceToken();
   }
 };

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -87,7 +87,6 @@ private:
   const Token *peek(int);
   ParserError error;
   void reportError(ParserErrorKind kind, const std::string &msg);
-  int savedPosition;
   bool parsingLhsExpression;
 
   // TODO: move these to ast helpers

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -187,12 +187,16 @@ void MLIRCodeGen::createVariable(shaderpulse::Type *type,
                                  VariableDeclaration *varDecl) {
   shaderpulse::Type *varType = (type) ? type : varDecl->getType();
 
+  if (varType->getKind() == TypeKind::Array) {
+    std::cout << "Array vardecl not supported" << std::endl;
+    return;
+  }
+
   if (inGlobalScope) {
     std::cout << "In global scope" << std::endl;
     spirv::StorageClass storageClass;
 
-    if (auto st = getSpirvStorageClass(
-            varType->getQualifier(TypeQualifierKind::Storage))) {
+    if (auto st = getSpirvStorageClass(varType->getQualifier(TypeQualifierKind::Storage))) {
       storageClass = *st;
     } else {
       storageClass = spirv::StorageClass::Private;
@@ -303,6 +307,12 @@ void MLIRCodeGen::visit(WhileStatement *whileStmt) {
 void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
   std::cout << "Visiting constructor expression" << std::endl;
   auto constructorType = constructorExp->getType();
+
+  if (constructorType->getKind() == TypeKind::Array) {
+    std::cout << "array constructors not supported " << std::endl;
+    return;
+  }
+
   std::vector<mlir::Value> operands;
 
   if (constructorExp->getArguments().size() > 0) {

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -322,8 +322,6 @@ void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
     }
   }
 
-  std::cout << "Operands: " << operands.size() << std::endl;
-
   switch (constructorType->getKind()) {
     case TypeKind::Struct: {
       auto structName = dynamic_cast<StructType*>(constructorType)->getName();
@@ -381,46 +379,34 @@ void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
 void MLIRCodeGen::visit(MemberAccessExpression *memberAccess) {
   auto baseComposite = memberAccess->getBaseComposite();
   baseComposite->accept(this);
-
   Value baseCompositeValue = popExpressionStack();
-
   std::vector<int> memberIndices;
-
   std::vector<mlir::Value> memberIndicesAcc;
 
   if (currentBaseComposite) {
-    std::cout << "Found base composite" << std::endl;
-
     for (auto &member : memberAccess->getMembers()) {
-        std::cout << "Members count: " << memberAccess->getMembers().size() << std::endl;
-        if (auto var = dynamic_cast<VariableExpression*>(member.get())) {
-          std::cout << "Found member variable: " << var->getName() << std::endl;
-          auto memberIndexPair = currentBaseComposite->getMemberWithIndex(var->getName());
-          memberIndices.push_back(memberIndexPair.first);
-          memberIndicesAcc.push_back(builder.create<spirv::ConstantOp>(builder.getUnknownLoc(), mlir::IntegerType::get(&context, 32, mlir::IntegerType::Signless), builder.getI32IntegerAttr(memberIndexPair.first)));
-          std::cout << "Index: " << memberIndexPair.first << std::endl;
-          std::cout << "index pair second: " <<  memberIndexPair.second->getType()->getKind() << std::endl;
+      if (auto var = dynamic_cast<VariableExpression*>(member.get())) {
+        auto memberIndexPair = currentBaseComposite->getMemberWithIndex(var->getName());
+        memberIndices.push_back(memberIndexPair.first);
+        memberIndicesAcc.push_back(builder.create<spirv::ConstantOp>(builder.getUnknownLoc(), mlir::IntegerType::get(&context, 32, mlir::IntegerType::Signless), builder.getI32IntegerAttr(memberIndexPair.first)));
 
-          if (memberIndexPair.second->getType()->getKind() == TypeKind::Struct) {
-            std::cout << "struct stuff" << std::endl;
-            auto structName = dynamic_cast<StructType*>(memberIndexPair.second->getType())->getName();
+        if (memberIndexPair.second->getType()->getKind() == TypeKind::Struct) {
+          auto structName = dynamic_cast<StructType*>(memberIndexPair.second->getType())->getName();
 
-            if (structDeclarations.find(structName) != structDeclarations.end()) {
-              currentBaseComposite = structDeclarations[structName];
-            }
+          if (structDeclarations.find(structName) != structDeclarations.end()) {
+            currentBaseComposite = structDeclarations[structName];
           }
         }
       }
+    }
 
-      if (memberAccess->isLhs()) {
-        Value accessChain = builder.create<spirv::AccessChainOp>(builder.getUnknownLoc(), baseCompositeValue, memberIndicesAcc);
-        expressionStack.push_back(accessChain);
-      } else {
-        Value compositeElement = builder.create<spirv::CompositeExtractOp>(builder.getUnknownLoc(), baseCompositeValue, memberIndices);
-        expressionStack.push_back(compositeElement);
-      }
-
-      std::cout << "Composite extract with " << memberIndices.size() << " index values" << std::endl;
+    if (memberAccess->isLhs()) {
+      Value accessChain = builder.create<spirv::AccessChainOp>(builder.getUnknownLoc(), baseCompositeValue, memberIndicesAcc);
+      expressionStack.push_back(accessChain);
+    } else {
+      Value compositeElement = builder.create<spirv::CompositeExtractOp>(builder.getUnknownLoc(), baseCompositeValue, memberIndices);
+      expressionStack.push_back(compositeElement);
+    }
   }
 }
 
@@ -485,29 +471,13 @@ void MLIRCodeGen::visit(IfStatement *ifStmt) {
 void MLIRCodeGen::visit(AssignmentExpression *assignmentExp) {
   std::cout << "Visiting assignment " << std::endl;
 
-  //std::cout << "Looking up " << assignmentExp->getIdentifier() << std::endl;
-  //auto varIt = symbolTable.lookup(assignmentExp->getIdentifier());
   assignmentExp->getUnaryExpression()->accept(this);
-
   assignmentExp->getExpression()->accept(this);
 
-  std::cout << "getExpression() accepted" << std::endl;
   Value val = popExpressionStack();
-
   Value ptr = popExpressionStack();
 
-  /*if (varIt.variable) {
-    if (varIt.isGlobal) {
-      auto addressOfGlobal = builder.create<mlir::spirv::AddressOfOp>(builder.getUnknownLoc(), varIt.ptrType, varIt.variable->getIdentifierName());
-      builder.create<spirv::StoreOp>(builder.getUnknownLoc(), addressOfGlobal, val);
-
-      if (insideEntryPoint) {
-        interface.push_back(SymbolRefAttr::get(&context, varIt.variable->getIdentifierName()));
-      }
-    } else {*/
-      builder.create<spirv::StoreOp>(builder.getUnknownLoc(), ptr, val);
-    /*}
-  }*/
+  builder.create<spirv::StoreOp>(builder.getUnknownLoc(), ptr, val);
 }
 
 void MLIRCodeGen::visit(StatementList *stmtList) {

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -52,12 +52,8 @@ std::unique_ptr<FunctionDeclaration> Parser::parseFunctionDeclaration() {
 
   if (parseQualifier()) {
     rollbackPosition();
-    std::cout << "rollback to: " << cursor << std::endl;
     return nullptr;
   }
-
-
-  std::cout << "no qualifier: " << cursor << std::endl;
 
   if (auto type = parseType()) {
     if (!(peek(1)->is(TokenKind::Identifier) &&
@@ -424,8 +420,7 @@ std::unique_ptr<LayoutQualifier> Parser::parseLayoutQualifier() {
   if (!curToken->is(TokenKind::rParen)) {
     return nullptr;
   }
-  
-  std::cout << "parsed layout qualitifer " << std::endl;
+
   return std::make_unique<LayoutQualifier>(std::move(layoutQualifierIds));
 }
 
@@ -454,7 +449,6 @@ std::unique_ptr<Type> Parser::parseType() {
 
   // Parse array type
   while (peek(1)->is(TokenKind::lBracket)) {
-    std::cout << "Array type detected " << std::endl;
     advanceToken();
     advanceToken();
 
@@ -476,7 +470,6 @@ std::unique_ptr<Type> Parser::parseType() {
   }
 
   if (dimensions.size() > 0) {
-    std::cout << "Dimensions: " << dimensions.size() <<  std::endl;
     return std::make_unique<ArrayType>(std::move(qualifiers), std::move(type), dimensions);
   } else {
     return type;
@@ -1249,16 +1242,12 @@ std::unique_ptr<Expression> Parser::parsePostfixExpression(bool parsingMemberAcc
 
 std::unique_ptr<ConstructorExpression> Parser::parseConstructorExpression() {
   savePosition();
-  std::cout << "Cursor: line: " << curToken->getSourceLocation().line << ", col: " << curToken->getSourceLocation().col << std::endl;
-  auto myType = parseType();
+  auto type = parseType();
 
-  if (!myType) {
-    std::cout << "no type" << std::endl;
+  if (!type) {
     rollbackPosition();
     return nullptr;
   }
-
-  std::cout << "Found type" << std::endl;
 
   advanceToken();
 
@@ -1271,7 +1260,7 @@ std::unique_ptr<ConstructorExpression> Parser::parseConstructorExpression() {
   advanceToken(); // eat lparen
 
   if (curToken->is(TokenKind::rParen)) {
-    return std::make_unique<ConstructorExpression>(std::move(myType));
+    return std::make_unique<ConstructorExpression>(std::move(type));
   }
 
   std::vector<std::unique_ptr<Expression>> arguments;
@@ -1297,7 +1286,7 @@ std::unique_ptr<ConstructorExpression> Parser::parseConstructorExpression() {
     return nullptr;
   }
 
-  return std::make_unique<ConstructorExpression>(std::move(myType), std::move(arguments));
+  return std::make_unique<ConstructorExpression>(std::move(type), std::move(arguments));
 }
 
 std::unique_ptr<StructDeclaration> Parser::parseStructDeclaration() {


### PR DESCRIPTION
- Parse array types such as `int[2][3] myIntArray;`
- Remove old logs

This PR does not handle cases when the array specifier is after the identifier name, such as `float[2] myArr[3];` 