### PR TITLE
Conditional expression

### DIFF
--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -19,9 +19,9 @@ void main() {
   A a = A(1.0, 2.0, 3.0, B(1.2, 1.3));
   float test = a.b.d;
   bool cond = true;
-  float bla = 1.0;
-  float blabla = 2.0;
-  float ternaryTest = cond ? bla : blabla;
+  float condTruePart = 1.0;
+  float condFalsePart = 2.0;
+  float ternaryTest = cond ? condTruePart : condFalsePart;
   int decl1=0,decl2,decl3;
   float[2] arr = float[2](1.0, 2.0);
 

--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -18,6 +18,10 @@ struct A {
 void main() {
   A a = A(1.0, 2.0, 3.0, B(1.2, 1.3));
   float test = a.b.d;
+  bool cond = true;
+  float bla = 1.0;
+  float blabla = 2.0;
+  float ternaryTest = cond ? bla : blabla;
   int decl1=0,decl2,decl3;
   float[2] arr = float[2](1.0, 2.0);
 

--- a/include/AST/AST.h
+++ b/include/AST/AST.h
@@ -244,6 +244,26 @@ private:
   std::unique_ptr<Expression> rhs;
 };
 
+class ConditionalExpression : public Expression {
+public:
+  ConditionalExpression( 
+    std::unique_ptr<Expression> condition,
+    std::unique_ptr<Expression> truePart,
+    std::unique_ptr<Expression> falsePart)
+      : condition(std::move(condition)), truePart(std::move(truePart)), falsePart(std::move(falsePart)) {}
+
+  void accept(ASTVisitor *visitor) override { visitor->visit(this); }
+
+  Expression *getCondition() { return condition.get(); }
+  Expression *getTruePart() { return truePart.get(); }
+  Expression *getFalsePart() { return falsePart.get(); }
+private:
+  std::unique_ptr<Expression> condition;
+  std::unique_ptr<Expression> truePart;
+  std::unique_ptr<Expression> falsePart;
+
+};
+
 class Statement : virtual public ASTNode {
 
 public:

--- a/include/AST/ASTVisitor.h
+++ b/include/AST/ASTVisitor.h
@@ -6,6 +6,7 @@ namespace ast {
 
 class TranslationUnit;
 class BinaryExpression;
+class ConditionalExpression;
 class UnaryExpression;
 class VariableDeclaration;
 class VariableDeclarationList;
@@ -41,6 +42,7 @@ public:
   virtual void visit(TranslationUnit *) { };
   virtual void visit(BinaryExpression *) { };
   virtual void visit(UnaryExpression *) { };
+  virtual void visit(ConditionalExpression *) { };
   virtual void visit(StructDeclaration *) { };
   virtual void visit(VariableDeclaration *) { };
   virtual void visit(VariableDeclarationList *) { };

--- a/include/AST/PrinterASTVisitor.h
+++ b/include/AST/PrinterASTVisitor.h
@@ -13,6 +13,7 @@ public:
   void visit(TranslationUnit *) override;
   void visit(BinaryExpression *) override;
   void visit(UnaryExpression *) override;
+  void visit(ConditionalExpression *) override;
   void visit(StructDeclaration *) override;
   void visit(VariableDeclaration *) override;
   void visit(VariableDeclarationList *) override;

--- a/include/CodeGen/MLIRCodeGen.h
+++ b/include/CodeGen/MLIRCodeGen.h
@@ -61,6 +61,7 @@ public:
   void visit(TranslationUnit *) override;
   void visit(BinaryExpression *) override;
   void visit(UnaryExpression *) override;
+  void visit(ConditionalExpression *) override;
   void visit(VariableDeclaration *) override;
   void visit(VariableDeclarationList *) override;
   void visit(SwitchStatement *) override;

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -66,6 +66,7 @@ public:
   std::unique_ptr<CaseLabel> parseCaseLabel();
   std::unique_ptr<DefaultLabel> parseDefaultLabel();
   std::unique_ptr<CallExpression> parseCallExpression();
+  std::unique_ptr<Expression> parseConditionalExpression();
   std::unique_ptr<ConstructorExpression> parseConstructorExpression();
   std::unique_ptr<Expression> parseUnaryExpression();
   std::unique_ptr<Expression> parsePostfixExpression(bool parsingMemberAccess = false);

--- a/lib/AST/PrinterASTVisitor.cpp
+++ b/lib/AST/PrinterASTVisitor.cpp
@@ -147,6 +147,10 @@ void PrinterASTVisitor::visit(BinaryExpression *binExp) {
   resetIndent();
 }
 
+void PrinterASTVisitor::visit(ConditionalExpression *condExp) {
+  // TODO: ConditionalExpression
+}
+
 void PrinterASTVisitor::visit(CallExpression *callee) {
   print("|-CallExpression: name=" + callee->getFunctionName());
 

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -132,6 +132,10 @@ void MLIRCodeGen::visit(BinaryExpression *binExp) {
   }
 }
 
+void MLIRCodeGen::visit(ConditionalExpression *condExp) {
+  std::cout << "Found conditional expression" << std::endl;
+}
+
 void MLIRCodeGen::visit(ForStatement *forStmt) {
   // TODO: implement me
 }

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -133,7 +133,22 @@ void MLIRCodeGen::visit(BinaryExpression *binExp) {
 }
 
 void MLIRCodeGen::visit(ConditionalExpression *condExp) {
-  std::cout << "Found conditional expression" << std::endl;
+  condExp->getFalsePart()->accept(this);
+  condExp->getTruePart()->accept(this);
+  condExp->getCondition()->accept(this);
+
+  Value condition = popExpressionStack();
+  Value truePart = popExpressionStack();
+  Value falsePart = popExpressionStack();
+
+  Value res = builder.create<spirv::SelectOp>(
+    builder.getUnknownLoc(),
+    /* Harcoded, fix me */ mlir::FloatType::getF32(&context),
+    condition,
+    truePart,
+    falsePart);
+
+  expressionStack.push_back(res);
 }
 
 void MLIRCodeGen::visit(ForStatement *forStmt) {

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -1378,10 +1378,7 @@ std::unique_ptr<CallExpression> Parser::parseCallExpression() {
 }
 
 std::unique_ptr<Expression> Parser::parseConditionalExpression() {
-  std::cout << "Trying parse conditional" << std::endl;
   auto condition = parseExpression();
-
-  std::cout << "Found condition" << std::endl;
 
   if (!curToken->is(TokenKind::question)) {
     return condition;
@@ -1391,8 +1388,6 @@ std::unique_ptr<Expression> Parser::parseConditionalExpression() {
 
   auto truePart = parseExpression();
 
-  std::cout << "Found true part" << std::endl;
-
   if (!curToken->is(TokenKind::colon)) {
     reportError(ParserErrorKind::ExpectedToken, "Expected a ':'");
     return nullptr;
@@ -1401,8 +1396,6 @@ std::unique_ptr<Expression> Parser::parseConditionalExpression() {
   advanceToken();
 
   auto falsePart = parseExpression();
-
-  std::cout << "Found false part" << std::endl;
 
   return std::make_unique<ConditionalExpression>(std::move(condition), std::move(truePart), std::move(falsePart));
 }

--- a/lib/Parser/Parser.cpp
+++ b/lib/Parser/Parser.cpp
@@ -113,7 +113,7 @@ std::unique_ptr<Declaration> Parser::parseDeclaration() {
       // Initializer expression
       advanceToken();
 
-      auto exp = parseExpression();
+      auto exp = parseConditionalExpression();
 
       // Declaration list
       if (curToken->is(TokenKind::comma)) {
@@ -163,7 +163,7 @@ std::unique_ptr<VariableDeclarationList> Parser::parseVariableDeclarationList(
     if (curToken->is(TokenKind::assign)) {
       advanceToken();
 
-      auto exp = parseExpression();
+      auto exp = parseConditionalExpression();
 
       if (!exp) {
         return nullptr;
@@ -716,7 +716,7 @@ std::unique_ptr<ForStatement> Parser::parseForStatement() {
     return nullptr;
   }
 
-  auto condExp = parseExpression();
+  auto condExp = parseConditionalExpression();
 
   if (!condExp) {
     return nullptr;
@@ -729,7 +729,7 @@ std::unique_ptr<ForStatement> Parser::parseForStatement() {
 
   advanceToken();
 
-  auto inductionExp = parseExpression();
+  auto inductionExp = parseConditionalExpression();
 
   if (!inductionExp) {
     return nullptr;
@@ -763,7 +763,7 @@ std::unique_ptr<SwitchStatement> Parser::parseSwitchStatement() {
 
   advanceToken();
 
-  auto exp = parseExpression();
+  auto exp = parseConditionalExpression();
 
   if (!exp) {
     return nullptr;
@@ -799,7 +799,7 @@ std::unique_ptr<WhileStatement> Parser::parseWhileStatement() {
 
   advanceToken();
 
-  auto exp = parseExpression();
+  auto exp = parseConditionalExpression();
 
   if (!curToken->is(TokenKind::rParen)) {
     reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after condition expression.");
@@ -837,7 +837,7 @@ std::unique_ptr<DoStatement> Parser::parseDoStatement() {
 
     advanceToken();
 
-    auto exp = parseExpression();
+    auto exp = parseConditionalExpression();
 
     if (!curToken->is(TokenKind::rParen)) {
       reportError(ParserErrorKind::ExpectedToken, "Expected a ')' after condition expression.");
@@ -873,7 +873,7 @@ std::unique_ptr<IfStatement> Parser::parseIfStatement() {
 
   advanceToken();
 
-  auto exp = parseExpression();
+  auto exp = parseConditionalExpression();
 
   if (!exp) {
     return nullptr;
@@ -917,7 +917,7 @@ std::unique_ptr<CaseLabel> Parser::parseCaseLabel() {
 
   advanceToken();
 
-  auto exp = parseExpression();
+  auto exp = parseConditionalExpression();
 
   if (!exp) {
     return nullptr;
@@ -1040,7 +1040,7 @@ std::unique_ptr<ReturnStatement> Parser::parseReturn() {
     return std::make_unique<ReturnStatement>();
   }
 
-  auto exp = parseExpression();
+  auto exp = parseConditionalExpression();
 
   if (!curToken->is(TokenKind::semiColon)) {
     reportError(ParserErrorKind::ExpectedToken, "Expected semicolon after return statement.");
@@ -1066,7 +1066,6 @@ std::unique_ptr<AssignmentExpression> Parser::parseAssignmentExpression() {
 
   parsingLhsExpression = false;
 
-
   if (!unaryExpression) {
     return nullptr;
   }
@@ -1074,7 +1073,7 @@ std::unique_ptr<AssignmentExpression> Parser::parseAssignmentExpression() {
   auto op = Parser::getAssignmentOperatorFromTokenKind(curToken->getTokenKind());
 
   advanceToken();
-  auto exp = parseExpression();
+  auto exp = parseConditionalExpression();
 
   if (!curToken->is(TokenKind::semiColon)) {
     reportError(ParserErrorKind::ExpectedToken, "Expected a semicolon after assignment expression.");
@@ -1158,7 +1157,7 @@ std::optional<std::vector<std::unique_ptr<Expression>>> Parser::parseMemberAcces
 }
 
 std::unique_ptr<Expression> Parser::parsePrimaryExpression() {
-   if (auto constructorExp = parseConstructorExpression()) {
+  if (auto constructorExp = parseConstructorExpression()) {
     return constructorExp;
   } else if (auto callExp = parseCallExpression()) {
     return callExp;
@@ -1189,7 +1188,7 @@ std::unique_ptr<Expression> Parser::parsePrimaryExpression() {
         curToken->is(TokenKind::kw_true));
   } else if (curToken->is(TokenKind::lParen)) {
     advanceToken();
-    auto exp = parseExpression();
+    auto exp = parseConditionalExpression();
 
     if (!exp) {
       return nullptr;
@@ -1270,7 +1269,7 @@ std::unique_ptr<ConstructorExpression> Parser::parseConstructorExpression() {
   std::vector<std::unique_ptr<Expression>> arguments;
 
   do {
-    auto exp = parseExpression();
+    auto exp = parseConditionalExpression();
 
     if (!exp) {
       return nullptr;
@@ -1355,7 +1354,7 @@ std::unique_ptr<CallExpression> Parser::parseCallExpression() {
   std::vector<std::unique_ptr<Expression>> arguments;
 
   do {
-    auto exp = parseExpression();
+    auto exp = parseConditionalExpression();
 
     if (!exp) {
       return nullptr;
@@ -1376,6 +1375,36 @@ std::unique_ptr<CallExpression> Parser::parseCallExpression() {
   }
 
   return std::make_unique<CallExpression>(name, std::move(arguments));
+}
+
+std::unique_ptr<Expression> Parser::parseConditionalExpression() {
+  std::cout << "Trying parse conditional" << std::endl;
+  auto condition = parseExpression();
+
+  std::cout << "Found condition" << std::endl;
+
+  if (!curToken->is(TokenKind::question)) {
+    return condition;
+  }
+
+  advanceToken();
+
+  auto truePart = parseExpression();
+
+  std::cout << "Found true part" << std::endl;
+
+  if (!curToken->is(TokenKind::colon)) {
+    reportError(ParserErrorKind::ExpectedToken, "Expected a ':'");
+    return nullptr;
+  }
+
+  advanceToken();
+
+  auto falsePart = parseExpression();
+
+  std::cout << "Found false part" << std::endl;
+
+  return std::make_unique<ConditionalExpression>(std::move(condition), std::move(truePart), std::move(falsePart));
 }
 
 void Parser::advanceToken() {


### PR DESCRIPTION
- Parse conditional expression: `a ? b : c` where `a` is a condition and `b`, `c` are expressions
- Replace most occurrences of `parseExpression` with `parseConditionalExpression`, as we're parsing cond exp first, than from inside that are other kinds of expressions parsed. This follows more closely the spec, but it's not yet 1:1, needs more work.
- Added support for conditional expression codegen through `spirv.Select`

AST printing is not yet supported.
