### PR TITLE
Parse, and codegen for array access

### DIFF
--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -24,6 +24,7 @@ void main() {
   float ternaryTest = cond ? condTruePart : condFalsePart;
   int decl1=0,decl2,decl3;
   float[2] arr = float[2](1.0, 2.0);
+  float testAccess = arr[0];
 
   for (int i = 0; i < 10; i++) {
     int j = 1;

--- a/include/AST/AST.h
+++ b/include/AST/AST.h
@@ -156,6 +156,23 @@ private:
   std::vector<std::unique_ptr<Expression>> members;
 };
 
+class ArrayAccessExpression : public Expression {
+  
+public:
+  ArrayAccessExpression(std::unique_ptr<Expression> array, std::vector<std::unique_ptr<Expression>> accessChain, bool lhs = false) :
+     Expression(lhs), array(std::move(array)), accessChain(std::move(accessChain)) {
+
+  }
+
+  void accept(ASTVisitor *visitor) override { visitor->visit(this); }
+  const std::vector<std::unique_ptr<Expression>> &getAccessChain() { return accessChain; }
+  Expression* getArray() const { return array.get(); }
+
+private:
+  std::unique_ptr<Expression> array;
+  std::vector<std::unique_ptr<Expression>> accessChain;
+};
+
 class CallExpression : public Expression {
 
 public:

--- a/include/AST/ASTVisitor.h
+++ b/include/AST/ASTVisitor.h
@@ -34,6 +34,7 @@ class FunctionDeclaration;
 class DefaultLabel;
 class CaseLabel;
 class MemberAccessExpression;
+class ArrayAccessExpression;
 
 class ASTVisitor {
 
@@ -56,6 +57,7 @@ public:
   virtual void visit(CallExpression *) { };
   virtual void visit(ConstructorExpression *) { };
   virtual void visit(MemberAccessExpression *) { };
+  virtual void visit(ArrayAccessExpression *) { };
   virtual void visit(VariableExpression *) { };
   virtual void visit(IntegerConstantExpression *) { };
   virtual void visit(UnsignedIntegerConstantExpression *) { };

--- a/include/AST/PrinterASTVisitor.h
+++ b/include/AST/PrinterASTVisitor.h
@@ -32,6 +32,7 @@ public:
   void visit(ConstructorExpression *) override;
   void visit(DoubleConstantExpression *) override;
   void visit(MemberAccessExpression *) override;
+  void visit(ArrayAccessExpression *) override;
   void visit(BoolConstantExpression *) override;
   void visit(ReturnStatement *) override;
   void visit(BreakStatement *) override;

--- a/include/AST/Types.h
+++ b/include/AST/Types.h
@@ -182,23 +182,23 @@ private:
 class ArrayType : public Type {
 
 public:
-  ArrayType(std::unique_ptr<Type> elementType, const std::vector<int>& dimensions)
+  ArrayType(std::unique_ptr<Type> elementType, const std::vector<int>& shape)
       : Type(TypeKind::Array, std::vector<std::unique_ptr<TypeQualifier>>()),
-        elementType(std::move(elementType)), dimensions(dimensions) {
+        elementType(std::move(elementType)), shape(shape) {
   }
   
   ArrayType(std::vector<std::unique_ptr<TypeQualifier>> qualifiers,
-             std::unique_ptr<Type> elementType, const std::vector<int>& dimensions)
+             std::unique_ptr<Type> elementType, const std::vector<int>& shape)
       : Type(TypeKind::Array, std::move(qualifiers)),
-        elementType(std::move(elementType)), dimensions(dimensions) {
+        elementType(std::move(elementType)), shape(shape) {
   }
 
   Type *getElementType() const { return elementType.get(); };
-  const std::vector<int> &getDimensions() { return dimensions; };
+  const std::vector<int> &getShape() { return shape; };
 
 private:
   std::unique_ptr<Type> elementType;
-  std::vector<int> dimensions;
+  std::vector<int> shape;
 };
 
 class MatrixType : public Type {

--- a/include/CodeGen/MLIRCodeGen.h
+++ b/include/CodeGen/MLIRCodeGen.h
@@ -74,6 +74,7 @@ public:
   void visit(CallExpression *) override;
   void visit(ConstructorExpression *) override;
   void visit(MemberAccessExpression *) override;
+  void visit(ArrayAccessExpression *) override;
   void visit(StructDeclaration *) override;
   void visit(VariableExpression *) override;
   void visit(IntegerConstantExpression *) override;

--- a/include/Parser/Parser.h
+++ b/include/Parser/Parser.h
@@ -69,13 +69,14 @@ public:
   std::unique_ptr<Expression> parseConditionalExpression();
   std::unique_ptr<ConstructorExpression> parseConstructorExpression();
   std::unique_ptr<Expression> parseUnaryExpression();
-  std::unique_ptr<Expression> parsePostfixExpression(bool parsingMemberAccess = false);
+  std::unique_ptr<Expression> parsePostfixExpression(bool parsingSubExpression = false);
   std::vector<std::unique_ptr<TypeQualifier>> parseQualifiers();
   std::unique_ptr<TypeQualifier> parseQualifier();
   std::unique_ptr<Type> parseType();
   std::unique_ptr<LayoutQualifier> parseLayoutQualifier();
   std::unique_ptr<StructDeclaration> parseStructDeclaration();
   std::optional<std::vector<std::unique_ptr<Expression>>> parseMemberAccessChain();
+  std::optional<std::vector<std::unique_ptr<Expression>>> parseArrayAccess();
 
 private:
   std::vector<std::unique_ptr<Token>> &tokenStream;

--- a/lib/AST/PrinterASTVisitor.cpp
+++ b/lib/AST/PrinterASTVisitor.cpp
@@ -226,6 +226,10 @@ void PrinterASTVisitor::visit(MemberAccessExpression *memberExp) {
   resetIndent();
 }
 
+void PrinterASTVisitor::visit(ArrayAccessExpression *arrayAccess) {
+  // TODO: implement me
+}
+
 void PrinterASTVisitor::visit(ReturnStatement *returnStmt) {
   print("|-ReturnStatement");
   

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -252,6 +252,7 @@ void MLIRCodeGen::createVariable(shaderpulse::Type *type,
     // builder.getUnitAttr());
   } else {
     if (varDecl->getInitialzerExpression()) {
+      std::cout << "Accept init" << std::endl;
       varDecl->getInitialzerExpression()->accept(this);
     }
 
@@ -396,6 +397,11 @@ void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
       // Unsupported composite construct
       break;
   }
+}
+
+void MLIRCodeGen::visit(ArrayAccessExpression *arrayAccess) {
+  // TODO: implement me
+  std::cout << "Visiting array access";
 }
 
 void MLIRCodeGen::visit(MemberAccessExpression *memberAccess) {

--- a/lib/CodeGen/TypeConversion.cpp
+++ b/lib/CodeGen/TypeConversion.cpp
@@ -19,6 +19,18 @@ mlir::Type convertShaderPulseType(mlir::MLIRContext *ctx, Type *shaderPulseType,
     return mlir::FloatType::getF32(ctx);
   case TypeKind::Double:
     return mlir::FloatType::getF64(ctx);
+  case TypeKind::Array: {
+    auto arrType = dynamic_cast<shaderpulse::ArrayType *>(shaderPulseType);
+    auto elementType = convertShaderPulseType(ctx, arrType->getElementType(), structDeclarations);
+    auto shape = arrType->getShape();
+    mlir::spirv::ArrayType spirvArrType = mlir::spirv::ArrayType::get(elementType, shape[shape.size()-1]);
+
+    for (int i = shape.size()-2; i >= 0; i--) {
+      spirvArrType = mlir::spirv::ArrayType::get(spirvArrType, shape[i]);
+    }
+
+    return spirvArrType;
+  }
   case TypeKind::Vector: {
     auto vecType = dynamic_cast<shaderpulse::VectorType *>(shaderPulseType);
     llvm::SmallVector<int64_t, 1> shape;


### PR DESCRIPTION
- Parse array access expressions: `someArray[expr1][expr2]`
- Convert `shaderpulse` array types to `spirv::mlir::ArrayType`
- Generate code for `ArrayAccessExpression`
- Generate code for array `ConstructorExpression`s