### PR TITLE
Typed binary operators

### DIFF
--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -10,6 +10,9 @@ struct Color {
 
 void main() {
   Color color = Color(1.0, 0.0, 0.0, 1.0);
+  uint b = 1u;
+  uint c = 2u;
+  bool a = c < b;
   outColor = vec4(color.r, color.g, color.b, color.a);
   return;
 }

--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -10,11 +10,6 @@ struct Color {
 
 void main() {
   Color color = Color(1.0, 0.0, 0.0, 1.0);
-  uint b = 1u;
-  uint c = 2u;
-  bool a = c < b;
-  float f = 1.0;
-  float g = -f;
   outColor = vec4(color.r, color.g, color.b, color.a);
   return;
 }

--- a/example/passthrough_fragment.glsl
+++ b/example/passthrough_fragment.glsl
@@ -13,6 +13,8 @@ void main() {
   uint b = 1u;
   uint c = 2u;
   bool a = c < b;
+  float f = 1.0;
+  float g = -f;
   outColor = vec4(color.r, color.g, color.b, color.a);
   return;
 }

--- a/include/CodeGen/MLIRCodeGen.h
+++ b/include/CodeGen/MLIRCodeGen.h
@@ -36,7 +36,7 @@ class MLIRCodeGen : public ASTVisitor {
 public:
   MLIRCodeGen();
   void initModuleOp();
-  void dump();
+  void print();
   bool verify();
   void visit(TranslationUnit *) override;
   void visit(BinaryExpression *) override;

--- a/include/CodeGen/MLIRCodeGen.h
+++ b/include/CodeGen/MLIRCodeGen.h
@@ -14,6 +14,7 @@
 #include "llvm/ADT/ScopedHashTable.h"
 #include <vector>
 #include <map>
+#include <utility>
 
 using namespace mlir;
 
@@ -80,7 +81,7 @@ private:
   bool inGlobalScope = true;
   llvm::StringMap<spirv::FuncOp> functionMap;
   llvm::StringMap<StructDeclaration*> structDeclarations;
-  std::vector<Value> expressionStack;
+  std::vector<std::pair<Type*, Value>> expressionStack;
   StructDeclaration* currentBaseComposite = nullptr;
 
   llvm::ScopedHashTable<llvm::StringRef, SymbolTableEntry>
@@ -95,7 +96,7 @@ private:
   void createVariable(shaderpulse::Type *, VariableDeclaration *);
   void insertEntryPoint();
   
-  mlir::Value popExpressionStack();
+  std::pair<Type*, Value> popExpressionStack();
   mlir::Value currentBasePointer;
   Type* typeContext;
 };

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -266,7 +266,11 @@ void MLIRCodeGen::visit(UnaryExpression *unExp) {
     expressionStack.push_back(rhs);
     break;
   case UnaryOperator::Dash:
-    val = builder.create<spirv::FNegateOp>(loc, rhs.second);
+    if (rhs.first->isFloatLike()) {
+      val = builder.create<spirv::FNegateOp>(loc, rhs.second);
+    } else {
+      val = builder.create<spirv::SNegateOp>(loc, rhs.second);
+    }
     expressionStack.push_back(std::make_pair(rhs.first, val));
     break;
   case UnaryOperator::Bang:
@@ -630,6 +634,7 @@ void MLIRCodeGen::visit(CallExpression *callExp) {
         builder.getUnknownLoc(), calledFunc.getFunctionType().getResults(),
         SymbolRefAttr::get(&context, calledFunc.getSymName()), operands);
 
+    // TODO: get return type of callee
     expressionStack.push_back(std::make_pair(nullptr, funcCall.getResult(0)));
   } else {
     std::cout << "Function not found." << callExp->getFunctionName()

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -31,8 +31,8 @@ void MLIRCodeGen::initModuleOp() {
   spirvModule = cast<spirv::ModuleOp>(Operation::create(state));
 }
 
-void MLIRCodeGen::dump() {
-  spirvModule.dump();
+void MLIRCodeGen::print() {
+  spirvModule.print(llvm::outs());
 }
 
 bool MLIRCodeGen::verify() { return !failed(mlir::verify(spirvModule)); }
@@ -288,8 +288,6 @@ void MLIRCodeGen::declare(SymbolTableEntry entry) {
   if (symbolTable.count(entry.variable->getIdentifierName()))
     return;
 
-
-  std::cout << "Declaring " << entry.variable->getIdentifierName() << std::endl;
   symbolTable.insert(entry.variable->getIdentifierName(), entry);
 }
 
@@ -345,7 +343,6 @@ void MLIRCodeGen::createVariable(shaderpulse::Type *type,
     // builder.getUnitAttr());
   } else {
     if (varDecl->getInitialzerExpression()) {
-      std::cout << "Accept init" << std::endl;
       varDecl->getInitialzerExpression()->accept(this);
     }
 
@@ -643,11 +640,9 @@ void MLIRCodeGen::visit(CallExpression *callExp) {
 }
 
 void MLIRCodeGen::visit(VariableExpression *varExp) {
-  std::cout << "Looking up " << varExp->getName() << std::endl;
   auto entry = symbolTable.lookup(varExp->getName());
 
   if (entry.variable) {
-    std::cout << "Looked up and found " << varExp->getName() << std::endl;
     Value val;
 
     if (entry.isGlobal) {

--- a/test/CodeGen/binary_expressions.glsl
+++ b/test/CodeGen/binary_expressions.glsl
@@ -1,0 +1,15 @@
+void main() {
+    // CHECK: %0 = spirv.IAdd %cst1_si32, %cst2_si32 : si3
+    int a = 1 + 2;
+
+    // CHECK: %2 = spirv.IAdd %cst1_ui32, %cst2_ui32 : ui32
+    uint c = 1u + 2u;
+
+    // CHECK: %4 = spirv.FAdd %cst_f32, %cst_f32_0 : f32
+    float b = 1.0f + 2.0f;
+
+    // CHECK: %6 = spirv.FAdd %cst_f64, %cst_f64_1 : f64
+    double d = 1.0lf + 2.0lf;
+
+    return;
+}

--- a/test/CodeGen/run_test.sh
+++ b/test/CodeGen/run_test.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+
+set -e
+
+SHADERPULSE="../../build/shaderpulse-standalone"
+FILECHECK="../../llvm-project/build/bin/FileCheck"
+
+if [ ! -x "$SHADERPULSE" ]; then
+  echo "Error: shaderpulse binary not found at $SHADERPULSE"
+  exit 1
+fi
+
+if [ ! -x "$FILECHECK" ]; then
+  echo "Error: FileCheck binary not found at $FILECHECK"
+  exit 1
+fi
+
+for TEST_FILE in *.glsl; do
+  if [ ! -f "$TEST_FILE" ]; then
+    echo "No .glsl files found in the current directory."
+    exit 1
+  fi
+
+  echo "Running test on $TEST_FILE"
+  $SHADERPULSE "$TEST_FILE" --no-analyze | $FILECHECK "$TEST_FILE"
+
+  if [ $? -eq 0 ]; then
+    echo "Test passed for $TEST_FILE"
+  else
+    echo "Test failed for $TEST_FILE"
+    exit 1
+  fi
+done


### PR DESCRIPTION
- Push `Type`-`Value` pairs onto the expression stack
- Select the correct binary operation (`IAdd`, `FAdd`, etc.) based on operand types
- Start work on code generation tests using `FileCheck` (only locally for now)
- `--no-analyze` option to disable semantic analysis
