### PR TITLE
Conversion ops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: macos-latest
 
     steps:
     - name: Checkout repository with submodules
@@ -26,7 +26,7 @@ jobs:
           ${{ runner.os }}-llvm-
 
     - name: Install Ninja
-      run: sudo apt-get install ninja-build
+      run: brew install ninja
 
     - name: Set up CMake
       uses: jwlawson/actions-setup-cmake@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,7 @@ jobs:
           -DLLVM_TARGETS_TO_BUILD="Native" \
           -DCMAKE_BUILD_TYPE=Release \
           -DLLVM_ENABLE_ASSERTIONS=ON
-        cmake --build . --target check-mlir
+        cmake --build .
 
     - name: Configure CMake for Shaderpulse
       run: cmake -B build -DENABLE_CODEGEN=ON -DCMAKE_BUILD_TYPE=Release

--- a/include/AST/Types.h
+++ b/include/AST/Types.h
@@ -128,11 +128,19 @@ public:
     return other.kind == kind;
   }
 
+  virtual bool isBoolLike() {
+    return kind == TypeKind::Bool;
+  }
+
   virtual bool isIntLike() {
     return kind == TypeKind::Integer || kind == TypeKind::UnsignedInteger;
   }
 
-  virtual bool isUintLike() {
+  virtual bool isSIntLike() {
+    return kind == TypeKind::Integer;
+  }
+
+  virtual bool isUIntLike() {
     return kind == TypeKind::UnsignedInteger;
   }
 
@@ -229,11 +237,19 @@ public:
     return false;
   }
 
+  bool isBoolLike() override {
+    return elementType->getKind() == TypeKind::Bool;
+  }
+
   bool isIntLike() override {
     return elementType->getKind() == TypeKind::Integer || elementType->getKind() == TypeKind::UnsignedInteger;
   }
 
-  bool isUintLike() override {
+  bool isSIntLike() override {
+    return elementType->getKind() == TypeKind::Integer;
+  }
+
+  bool isUIntLike() override {
     return elementType->getKind() == TypeKind::UnsignedInteger;
   }
 
@@ -295,6 +311,26 @@ public:
     return false;
   }
 
+  bool isBoolLike() override {
+    return elementType->getKind() == TypeKind::Bool;
+  }
+
+  bool isIntLike() override {
+    return elementType->getKind() == TypeKind::Integer || elementType->getKind() == TypeKind::UnsignedInteger;
+  }
+
+  bool isSIntLike() override {
+    return elementType->getKind() == TypeKind::Integer;
+  }
+
+  bool isUIntLike() override {
+    return elementType->getKind() == TypeKind::UnsignedInteger;
+  }
+
+  bool isFloatLike() override {
+    return elementType->getKind() == TypeKind::Float || elementType->getKind() == TypeKind::Double;
+  }
+
   std::string toString() override {
     std::string arrStr = elementType->toString();
 
@@ -335,6 +371,26 @@ public:
     }
 
     return false;
+  }
+
+  bool isBoolLike() override {
+    return elementType->getKind() == TypeKind::Bool;
+  }
+
+  bool isIntLike() override {
+    return elementType->getKind() == TypeKind::Integer || elementType->getKind() == TypeKind::UnsignedInteger;
+  }
+
+  bool isSIntLike() override {
+    return elementType->getKind() == TypeKind::Integer;
+  }
+
+  bool isUIntLike() override {
+    return elementType->getKind() == TypeKind::UnsignedInteger;
+  }
+
+  bool isFloatLike() override {
+    return elementType->getKind() == TypeKind::Float || elementType->getKind() == TypeKind::Double;
   }
 
   std::string toString() override {

--- a/include/AST/Types.h
+++ b/include/AST/Types.h
@@ -148,6 +148,14 @@ public:
     return kind == TypeKind::Float || kind == TypeKind::Double;
   }
 
+  virtual bool isF32Like() {
+    return kind == TypeKind::Float;
+  }
+
+  virtual bool isF64Like() {
+    return kind == TypeKind::Double;
+  }
+
   virtual std::string toString() {
     switch (kind) {
       case TypeKind::Integer:
@@ -257,6 +265,14 @@ public:
     return elementType->getKind() == TypeKind::Float || elementType->getKind() == TypeKind::Double;
   }
 
+  bool isF32Like() override {
+    return elementType->getKind() == TypeKind::Float;
+  }
+
+  bool isF64Like() override {
+    return elementType->getKind() == TypeKind::Double;
+  }
+
   std::string toString() override {
     std::string prefix = "";
 
@@ -331,6 +347,14 @@ public:
     return elementType->getKind() == TypeKind::Float || elementType->getKind() == TypeKind::Double;
   }
 
+  bool isF32Like() override {
+    return elementType->getKind() == TypeKind::Float;
+  }
+
+  bool isF64Like() override {
+    return elementType->getKind() == TypeKind::Double;
+  }
+
   std::string toString() override {
     std::string arrStr = elementType->toString();
 
@@ -391,6 +415,14 @@ public:
 
   bool isFloatLike() override {
     return elementType->getKind() == TypeKind::Float || elementType->getKind() == TypeKind::Double;
+  }
+
+  bool isF32Like() override {
+    return elementType->getKind() == TypeKind::Float;
+  }
+
+  bool isF64Like() override {
+    return elementType->getKind() == TypeKind::Double;
   }
 
   std::string toString() override {

--- a/include/CodeGen/MLIRCodeGen.h
+++ b/include/CodeGen/MLIRCodeGen.h
@@ -101,6 +101,7 @@ private:
   
   std::pair<Type*, Value> popExpressionStack();
   mlir::Value currentBasePointer;
+  mlir::Value convertOp(ConstructorExpression* constructorExp);
 };
 
 }; // namespace codegen

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -103,7 +103,7 @@ void MLIRCodeGen::visit(BinaryExpression *binExp) {
     expressionStack.push_back(std::make_pair(typeContext, val));
     break;
   case BinaryOperator::Div:
-    if (typeContext->isUintLike()) {
+    if (typeContext->isUIntLike()) {
       val = builder.create<spirv::UDivOp>(loc, lhs, rhs);
     } else if (typeContext->isIntLike()) {
       val = builder.create<spirv::SDivOp>(loc, lhs, rhs);
@@ -133,7 +133,7 @@ void MLIRCodeGen::visit(BinaryExpression *binExp) {
   case BinaryOperator::Lt:
     if (typeContext->isFloatLike()) {
       val = builder.create<spirv::FOrdLessThanOp>(loc, lhs, rhs);
-    } else if (typeContext->isUintLike()) {
+    } else if (typeContext->isUIntLike()) {
       val = builder.create<spirv::ULessThanOp>(loc, lhs, rhs);
     } else {
       val = builder.create<spirv::SLessThanOp>(loc, lhs, rhs);
@@ -143,7 +143,7 @@ void MLIRCodeGen::visit(BinaryExpression *binExp) {
   case BinaryOperator::Gt:
     if (typeContext->isFloatLike()) {
       val = builder.create<spirv::FOrdGreaterThanOp>(loc, lhs, rhs);
-    } else if (typeContext->isUintLike()) {
+    } else if (typeContext->isUIntLike()) {
       val = builder.create<spirv::UGreaterThanOp>(loc, lhs, rhs);
     } else {
       val = builder.create<spirv::SGreaterThanOp>(loc, lhs, rhs);
@@ -153,7 +153,7 @@ void MLIRCodeGen::visit(BinaryExpression *binExp) {
   case BinaryOperator::LtEq:
     if (typeContext->isFloatLike()) {
       val = builder.create<spirv::FOrdLessThanEqualOp>(loc, lhs, rhs);
-    } else if (typeContext->isUintLike()) {
+    } else if (typeContext->isUIntLike()) {
       val = builder.create<spirv::ULessThanEqualOp>(loc, lhs, rhs);
     } else {
       val = builder.create<spirv::SLessThanEqualOp>(loc, lhs, rhs);
@@ -163,7 +163,7 @@ void MLIRCodeGen::visit(BinaryExpression *binExp) {
   case BinaryOperator::GtEq:
     if (typeContext->isFloatLike()) {
       val = builder.create<spirv::FOrdGreaterThanEqualOp>(loc, lhs, rhs);
-    } else if (typeContext->isUintLike()) {
+    } else if (typeContext->isUIntLike()) {
       val = builder.create<spirv::UGreaterThanEqualOp>(loc, lhs, rhs);
     } else {
       val = builder.create<spirv::SGreaterThanEqualOp>(loc, lhs, rhs);
@@ -267,8 +267,8 @@ void MLIRCodeGen::visit(UnaryExpression *unExp) {
     if (rhsType->isIntLike()) {
       auto one = builder.create<spirv::ConstantOp>(
         builder.getUnknownLoc(),
-        mlir::IntegerType::get(&context, 32, rhsType->isUintLike() ? mlir::IntegerType::Unsigned : mlir::IntegerType::Signed),
-        rhsType->isUintLike() ? builder.getUI32IntegerAttr(1) :builder.getSI32IntegerAttr(1)
+        mlir::IntegerType::get(&context, 32, rhsType->isUIntLike() ? mlir::IntegerType::Unsigned : mlir::IntegerType::Signed),
+        rhsType->isUIntLike() ? builder.getUI32IntegerAttr(1) :builder.getSI32IntegerAttr(1)
       );
 
       if (op == UnaryOperator::Inc) {
@@ -504,24 +504,54 @@ void MLIRCodeGen::visit(ConstructorExpression *constructorExp) {
     }
 
     // Scalar type conversions
-    case TypeKind::Float:
-    case TypeKind::Double: {
-      if (constructorExp->getArguments().size() > 0) {
-        constructorExp->getArguments()[0]->accept(this);
-        auto typeValPair = popExpressionStack();
-        Type* fromType = typeValPair.first;
-        mlir::Value val = load(typeValPair.second);
-        mlir::Type resultType = convertShaderPulseType(&context, constructorType, structDeclarations);
-
-        if (fromType->isUintLike()) {
-          expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::ConvertUToFOp>(builder.getUnknownLoc(), resultType, val)));
-        } else if (fromType->isIntLike()) {
-          expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::ConvertSToFOp>(builder.getUnknownLoc(), resultType, val)));
-        } else {
-          expressionStack.push_back(typeValPair);
-        }
-      }
+    default:
+      convertOp(constructorExp);
       break;
+  }
+}
+
+mlir::Value MLIRCodeGen::convertOp(ConstructorExpression* constructorExp) {
+  if (constructorExp->getArguments().size() > 0) {
+    constructorExp->getArguments()[0]->accept(this);
+    auto typeValPair = popExpressionStack();
+    shaderpulse::Type* toType = constructorExp->getType();
+    shaderpulse::Type* fromType = typeValPair.first;
+    mlir::Value val = load(typeValPair.second);
+    mlir::Type resultType = convertShaderPulseType(&context, toType, structDeclarations);
+
+    if (fromType->isUIntLike() && toType->isFloatLike()) {
+      expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::ConvertUToFOp>(builder.getUnknownLoc(), resultType, val)));
+    } else if (fromType->isIntLike() && toType->isFloatLike()) {
+      expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::ConvertSToFOp>(builder.getUnknownLoc(), resultType, val)));
+    } else if (fromType->isFloatLike() && toType->isUIntLike()) {
+      expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::ConvertFToUOp>(builder.getUnknownLoc(), resultType, val)));
+    } else if (fromType->isFloatLike() && toType->isIntLike()) {
+      expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::ConvertFToSOp>(builder.getUnknownLoc(), resultType, val)));
+    } else if ((fromType->isSIntLike() && toType->isUIntLike()) || (fromType->isUIntLike() && toType->isSIntLike())) {
+      expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::BitcastOp>(builder.getUnknownLoc(), resultType, val)));
+    } else if (fromType->isBoolLike() && toType->isIntLike()) {
+      auto one = builder.create<spirv::ConstantOp>(
+        builder.getUnknownLoc(),
+        mlir::IntegerType::get(&context, 32, toType->isUIntLike() ? mlir::IntegerType::Unsigned : mlir::IntegerType::Signed),
+        toType->isUIntLike() ? builder.getUI32IntegerAttr(1) : builder.getSI32IntegerAttr(1)
+      );
+
+      auto zero = builder.create<spirv::ConstantOp>(
+        builder.getUnknownLoc(),
+        mlir::IntegerType::get(&context, 32, toType->isUIntLike() ? mlir::IntegerType::Unsigned : mlir::IntegerType::Signed),
+        toType->isUIntLike() ? builder.getUI32IntegerAttr(0) : builder.getSI32IntegerAttr(0)
+      );
+
+       mlir::Value res = builder.create<spirv::SelectOp>(
+        builder.getUnknownLoc(),
+        resultType,
+        val,
+        one,
+        zero
+      );
+      expressionStack.push_back(std::make_pair(constructorExp->getType(), res));
+    } else {
+      expressionStack.push_back(typeValPair);
     }
   }
 }

--- a/lib/CodeGen/MLIRCodeGen.cpp
+++ b/lib/CodeGen/MLIRCodeGen.cpp
@@ -550,6 +550,8 @@ mlir::Value MLIRCodeGen::convertOp(ConstructorExpression* constructorExp) {
         zero
       );
       expressionStack.push_back(std::make_pair(constructorExp->getType(), res));
+    } else if ((fromType->isF32Like() && toType->isF64Like()) || (fromType->isF64Like() && toType->isF32Like())) {
+      expressionStack.push_back(std::make_pair(constructorExp->getType(), builder.create<spirv::FConvertOp>(builder.getUnknownLoc(), resultType, val)));
     } else {
       expressionStack.push_back(typeValPair);
     }

--- a/test/CodeGen/conversions.glsl
+++ b/test/CodeGen/conversions.glsl
@@ -3,7 +3,42 @@ void main() {
 
     uint b = 2u;
 
-    float c = float(a);
+    float c = 1.0;
 
-    float d = float(b);
+    double d = 1.0lf;
+
+    bool e = true;
+
+    // CHECK: %6 = spirv.Bitcast %5 : ui32 to si32
+    //      int(uint)
+    int e = int(b);
+
+    // CHECK:  %8 = spirv.Load "Function" %4 : i1
+    // CHECK-NEXT: %cst1_si32_0 = spirv.Constant 1 : si32
+    // CHECK-NEXT: %cst0_si32 = spirv.Constant 0 : si32
+    // CHECK-NEXT: %9 = spirv.Select %8, %cst1_si32_0, %cst0_si32 : i1, si32
+    //      int(bool)
+    int f = int(e);
+
+    // CHECK: %12 = spirv.ConvertFToS %11 : f32 to si32
+    //      int(float)
+    int g = int(c);
+
+    // CHECK: %15 = spirv.ConvertFToS %14 : f64 to si32
+    //      int(double)
+    int h = int(d);
+
+
+
+    //       uint(int)
+    uint i = uint(a);
+
+    //       uint(bool)
+    uint j = uint(e);
+
+    //       uint(float)
+    uint k = uint(c);
+
+    //       uint(double)
+    uint l = uint(d);
 }

--- a/test/CodeGen/conversions.glsl
+++ b/test/CodeGen/conversions.glsl
@@ -1,0 +1,9 @@
+void main() {
+    int a = 1;
+
+    uint b = 2u;
+
+    float c = float(a);
+
+    float d = float(b);
+}

--- a/test/CodeGen/conversions.glsl
+++ b/test/CodeGen/conversions.glsl
@@ -1,44 +1,70 @@
 void main() {
-    int a = 1;
+    int _int = 1;
 
-    uint b = 2u;
+    uint _uint = 2u;
 
-    float c = 1.0;
+    float _float = 1.0;
 
-    double d = 1.0lf;
+    double _double = 1.0lf;
 
-    bool e = true;
+    bool _bool = true;
 
     // CHECK: %6 = spirv.Bitcast %5 : ui32 to si32
-    //      int(uint)
-    int e = int(b);
+    int e = int(_uint);
 
     // CHECK:  %8 = spirv.Load "Function" %4 : i1
     // CHECK-NEXT: %cst1_si32_0 = spirv.Constant 1 : si32
     // CHECK-NEXT: %cst0_si32 = spirv.Constant 0 : si32
     // CHECK-NEXT: %9 = spirv.Select %8, %cst1_si32_0, %cst0_si32 : i1, si32
-    //      int(bool)
-    int f = int(e);
+    int f = int(_bool);
 
     // CHECK: %12 = spirv.ConvertFToS %11 : f32 to si32
-    //      int(float)
-    int g = int(c);
+    int g = int(_float);
 
     // CHECK: %15 = spirv.ConvertFToS %14 : f64 to si32
-    //      int(double)
-    int h = int(d);
+    int h = int(_double);
 
 
+    // CHECK: %18 = spirv.Bitcast %17 : si32 to ui32
+    uint i = uint(_int);
 
-    //       uint(int)
-    uint i = uint(a);
+    // CHECK: %cst1_ui32 = spirv.Constant 1 : ui32
+    // CHECK-NEXT: %cst0_ui32 = spirv.Constant 0 : ui32
+    // CHECK-NEXT: %21 = spirv.Select %20, %cst1_ui32, %cst0_ui32 : i1, ui32
+    uint j = uint(_bool);
 
-    //       uint(bool)
-    uint j = uint(e);
+    // CHECK: %24 = spirv.ConvertFToU %23 : f32 to ui32
+    uint k = uint(_float);
 
-    //       uint(float)
-    uint k = uint(c);
+    // CHECK: %27 = spirv.ConvertFToU %26 : f64 to ui32
+    uint l = uint(_double);
 
-    //       uint(double)
-    uint l = uint(d);
+    /*
+        bool(int)
+        bool(uint)
+        bool(float)
+        bool(double)
+    */
+
+    // CHECK: %30 = spirv.ConvertSToF %29 : si32 to f32
+    float k = float(_int);
+
+    // CHECK: %33 = spirv.ConvertUToF %32 : ui32 to f32
+    float m = float(_uint);
+
+    // float n = float(_bool);
+
+    // CHECK: %36 = spirv.FConvert %35 : f64 to f32
+    float o = float(_double);
+
+    // CHECK: %39 = spirv.ConvertSToF %38 : si32 to f64
+    double p = double(_int);
+
+    // CHECK: %42 = spirv.ConvertUToF %41 : ui32 to f64
+    double q = double(_uint);
+
+    // double r = double(_bool);
+
+    // CHECK: %45 = spirv.FConvert %44 : f32 to f64
+    double s = double(_float);
 }

--- a/test/CodeGen/conversions.glsl
+++ b/test/CodeGen/conversions.glsl
@@ -39,13 +39,6 @@ void main() {
     // CHECK: %27 = spirv.ConvertFToU %26 : f64 to ui32
     uint l = uint(_double);
 
-    /*
-        bool(int)
-        bool(uint)
-        bool(float)
-        bool(double)
-    */
-
     // CHECK: %30 = spirv.ConvertSToF %29 : si32 to f32
     float k = float(_int);
 
@@ -67,4 +60,20 @@ void main() {
 
     // CHECK: %45 = spirv.FConvert %44 : f32 to f64
     double s = double(_float);
+
+    // CHECK: %cst0_si32_1 = spirv.Constant 0 : si32
+    // CHECK-NEXT: %48 = spirv.INotEqual %47, %cst0_si32_1 : si32
+    bool t = bool(_int);
+
+    // CHECK: %cst0_ui32_2 = spirv.Constant 0 : ui32
+    // CHECK-NEXT: %51 = spirv.INotEqual %50, %cst0_ui32_2 : ui32
+    bool u = bool(_uint);
+
+    // CHECK: %cst_f32_3 = spirv.Constant 0.000000e+00 : f32
+    // CHECK-NEXT: %54 = spirv.FOrdNotEqual %53, %cst_f32_3 : f32
+    bool v = bool(_float);
+
+    // CHECK: %cst_f64_4 = spirv.Constant 0.000000e+00 : f64
+    // CHECK-NEXT: %57 = spirv.FOrdNotEqual %56, %cst_f64_4 : f64
+    bool w = bool(_double);
 }

--- a/test/CodeGen/run_tests.sh
+++ b/test/CodeGen/run_tests.sh
@@ -28,12 +28,31 @@ for TEST_FILE in *.glsl; do
   fi
 
   echo "Running test on $TEST_FILE"
-  $SHADERPULSE "$TEST_FILE" --no-analyze | $FILECHECK "$TEST_FILE"
+  
+  # Create a temporary file to capture output and errors
+  OUTPUT_FILE=$(mktemp)
+  STDERR_FILE=$(mktemp)
 
+  # Run shaderpulse and redirect both stdout and stderr
+  $SHADERPULSE "$TEST_FILE" --no-analyze > "$OUTPUT_FILE" 2> "$STDERR_FILE"
+
+  # Display stderr content if there are issues
+  if [ -s "$STDERR_FILE" ]; then
+    echo "Shaderpulse stderr output:"
+    cat "$STDERR_FILE"
+  fi
+
+  # Run FileCheck with the captured output
+  $FILECHECK "$TEST_FILE" < "$OUTPUT_FILE"
+
+  # Check if FileCheck passed
   if [ $? -eq 0 ]; then
     echo "Test passed for $TEST_FILE"
   else
     echo "Test failed for $TEST_FILE"
     exit 1
   fi
+
+  # Clean up temporary files
+  rm "$OUTPUT_FILE" "$STDERR_FILE"
 done

--- a/test/CodeGen/run_tests.sh
+++ b/test/CodeGen/run_tests.sh
@@ -21,38 +21,13 @@ for TEST_FILE in *.glsl; do
     exit 1
   fi
 
-  # functions tests are failing in CI due to some pointer alignment issue
-  if [ "$CI" = "1" ] && [ "$TEST_FILE" = "functions.glsl" ]; then
-    echo "Skipping test for $TEST_FILE - errors in CI"
-    continue
-  fi
-
   echo "Running test on $TEST_FILE"
-  
-  # Create a temporary file to capture output and errors
-  OUTPUT_FILE=$(mktemp)
-  STDERR_FILE=$(mktemp)
+  $SHADERPULSE "$TEST_FILE" --no-analyze | $FILECHECK "$TEST_FILE"
 
-  # Run shaderpulse and redirect both stdout and stderr
-  $SHADERPULSE "$TEST_FILE" --no-analyze > "$OUTPUT_FILE" 2> "$STDERR_FILE"
-
-  # Display stderr content if there are issues
-  if [ -s "$STDERR_FILE" ]; then
-    echo "Shaderpulse stderr output:"
-    cat "$STDERR_FILE"
-  fi
-
-  # Run FileCheck with the captured output
-  $FILECHECK "$TEST_FILE" < "$OUTPUT_FILE"
-
-  # Check if FileCheck passed
   if [ $? -eq 0 ]; then
     echo "Test passed for $TEST_FILE"
   else
     echo "Test failed for $TEST_FILE"
     exit 1
   fi
-
-  # Clean up temporary files
-  rm "$OUTPUT_FILE" "$STDERR_FILE"
 done


### PR DESCRIPTION
This PR adds support for all scalar type conversions, excluding only `bool -> float` and `bool -> double`
The implementation follows the spec: `5.4.1. Conversion and Scalar Constructors`
Tests have been added to check the various conversion.
The code will be reused for composite conversions as well.